### PR TITLE
Add terrain LOD

### DIFF
--- a/editor/src/EntityView.cpp
+++ b/editor/src/EntityView.cpp
@@ -442,31 +442,18 @@ void EntityView::DrawTerrainComponent(Entity selectedEntity, World* world)
 		{
 			bool edited = false;
 
-			float minHeight = terrainSystem->GetMinHeight(terrainId);
-			float maxHeight = terrainSystem->GetMaxHeight(terrainId);
-			float heightRange = maxHeight - minHeight;
-
 			float terrainSize = terrainSystem->GetSize(terrainId);
+			float heightOrigin = terrainSystem->GetBottom(terrainId);
+			float heightRange = terrainSystem->GetHeight(terrainId);
+
 			if (ImGui::DragFloat("Terrain size", &terrainSize, 1.0f, 1.0f))
 				terrainSystem->SetSize(terrainId, terrainSize);
 
-			if (ImGui::DragFloat("Height origin", &minHeight, 0.1f))
-			{
-				edited = true;
-				maxHeight = minHeight + heightRange;
-			}
+			if (ImGui::DragFloat("Height origin", &heightOrigin, 0.1f))
+				terrainSystem->SetBottom(terrainId, heightOrigin);
 
 			if (ImGui::DragFloat("Height range", &heightRange, 0.1f, 0.1f))
-			{
-				edited = true;
-				maxHeight = minHeight + heightRange;
-			}
-
-			if (edited)
-			{
-				terrainSystem->SetMinHeight(terrainId, minHeight);
-				terrainSystem->SetMaxHeight(terrainId, maxHeight);
-			}
+				terrainSystem->SetHeight(terrainId, heightRange);
 
 			Vec2f textureScale = terrainSystem->GetTextureScale(terrainId);
 			if (ImGui::DragFloat2("Texture scale", textureScale.ValuePointer(), 0.01f, 0.01f))

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -131,6 +131,7 @@ set (KOKKO_SOURCES
 	src/Graphics/TerrainInstance.hpp
 	src/Graphics/TerrainSystem.cpp
 	src/Graphics/TerrainSystem.hpp
+	src/Graphics/TerrainTileId.hpp
 	src/Graphics/TerrainQuadTree.cpp
 	src/Graphics/TerrainQuadTree.hpp
 	src/Graphics/TransformSerializer.hpp

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -131,6 +131,8 @@ set (KOKKO_SOURCES
 	src/Graphics/TerrainInstance.hpp
 	src/Graphics/TerrainSystem.cpp
 	src/Graphics/TerrainSystem.hpp
+	src/Graphics/TerrainQuadTree.cpp
+	src/Graphics/TerrainQuadTree.hpp
 	src/Graphics/TransformSerializer.hpp
 	src/Graphics/TransformUpdateReceiver.hpp
 	src/Graphics/Scene.cpp

--- a/engine/res/shaders/deferred_geometry/terrain.glsl
+++ b/engine/res/shaders/deferred_geometry/terrain.glsl
@@ -16,8 +16,8 @@ layout(std140, binding = BLOCK_BINDING_OBJECT) uniform TerrainBlock
 	float tile_scale;
 	float terrain_size;
 	float terrain_resolution;
-	float min_height;
-	float max_height;
+	float height_origin;
+	float height_range;
 }
 uniforms;
 
@@ -39,7 +39,7 @@ float sample_height(vec2 offset)
 void main()
 {
 	float offset_amount = 1.0 / uniforms.terrain_resolution;
-	float y_extent = uniforms.max_height - uniforms.min_height;
+	float y_extent = uniforms.height_range;
 	float w_offset = uniforms.terrain_size / uniforms.terrain_resolution * 2.0;
 
 	float h0 = sample_height(vec2(0.0, 0.0));
@@ -61,7 +61,7 @@ void main()
 
 	vec2 w_pos = (position + uniforms.tile_offset) * uniforms.terrain_size * uniforms.tile_scale;
 
-	gl_Position = uniforms.MVP * vec4(w_pos.x, uniforms.min_height + h0 * y_extent, w_pos.y, 1.0);
+	gl_Position = uniforms.MVP * vec4(w_pos.x, uniforms.height_origin + h0 * y_extent, w_pos.y, 1.0);
 
 	vs_out.normal = normalize(vec3(uniforms.MV * vec4(w_normal, 0.0)));
 	vs_out.tex_coord = w_pos * uniforms.texture_scale;

--- a/engine/res/shaders/deferred_geometry/terrain.glsl
+++ b/engine/res/shaders/deferred_geometry/terrain.glsl
@@ -12,6 +12,8 @@ layout(std140, binding = BLOCK_BINDING_OBJECT) uniform TerrainBlock
 	mat4x4 MVP;
 	mat4x4 MV;
 	vec2 texture_scale;
+	vec2 tile_offset;
+	float tile_scale;
 	float terrain_size;
 	float terrain_resolution;
 	float min_height;
@@ -57,7 +59,7 @@ void main()
 
 	vec3 w_normal = cross(normalize(z_tan), normalize(x_tan));
 
-	vec2 w_pos = (position - 0.5) * uniforms.terrain_size;
+	vec2 w_pos = (position + uniforms.tile_offset) * uniforms.terrain_size * uniforms.tile_scale;
 
 	gl_Position = uniforms.MVP * vec4(w_pos.x, uniforms.min_height + h0 * y_extent, w_pos.y, 1.0);
 

--- a/engine/src/Debug/Debug.cpp
+++ b/engine/src/Debug/Debug.cpp
@@ -33,6 +33,8 @@
 #include "System/Time.hpp"
 #include "System/Window.hpp"
 
+Debug* Debug::singletonInstance = nullptr;
+
 static void RenderDebugCallback(const RenderDevice::DebugMessage& message)
 {
 	if (message.severity != RenderDebugSeverity::Notification)
@@ -66,10 +68,14 @@ Debug::Debug(
 	Log::SetLogInstance(log);
 
 	memoryStats = allocator->MakeNew<DebugMemoryStats>(allocManager, textRenderer);
+
+	singletonInstance = this;
 }
 
 Debug::~Debug()
 {
+	singletonInstance = nullptr;
+
 	allocator->MakeDelete(memoryStats);
 
 	// Clear log instance in LogHelper

--- a/engine/src/Debug/Debug.hpp
+++ b/engine/src/Debug/Debug.hpp
@@ -28,6 +28,8 @@ struct CameraParameters;
 class Debug
 {
 private:
+	static Debug* singletonInstance;
+
 	Allocator* allocator;
 	RenderDevice* renderDevice;
 
@@ -62,6 +64,8 @@ public:
 	Debug(Allocator* allocator, AllocatorManager* allocManager,
 		Window* window, RenderDevice* renderDevice, Filesystem* filesystem);
 	~Debug();
+
+	static Debug* Get() { return singletonInstance; }
 
 	void Initialize(Window* window, MeshManager* meshManager,
 		ShaderManager* shaderManager, TextureManager* textureManager);

--- a/engine/src/Debug/Debug.hpp
+++ b/engine/src/Debug/Debug.hpp
@@ -2,6 +2,8 @@
 
 #include "Core/Optional.hpp"
 
+#include "Math/Vec2.hpp"
+
 class Allocator;
 class AllocatorManager;
 class RenderDevice;
@@ -70,7 +72,7 @@ public:
 	void Initialize(Window* window, MeshManager* meshManager,
 		ShaderManager* shaderManager, TextureManager* textureManager);
 	void Deinitialize();
-	
+
 	void Render(World* world, const Framebuffer& framebuffer, const Optional<CameraParameters>& editorCamera);
 
 	DebugLog* GetLog() { return log; }

--- a/engine/src/Debug/DebugTextRenderer.cpp
+++ b/engine/src/Debug/DebugTextRenderer.cpp
@@ -69,16 +69,12 @@ void DebugTextRenderer::Initialize(ShaderManager* shaderManager,
 
 void DebugTextRenderer::SetFrameSize(const Vec2f& size)
 {
-	assert(displayData.GetCount() == 0);
-
 	frameSize = size;
 	scaledFrameSize = size * (1.0f / scaleFactor);
 }
 
 void DebugTextRenderer::SetScaleFactor(float scale)
 {
-	assert(displayData.GetCount() == 0);
-
 	scaleFactor = scale;
 	scaledFrameSize = frameSize * (1.0f / scaleFactor);
 }

--- a/engine/src/Engine/EntityFactory.cpp
+++ b/engine/src/Engine/EntityFactory.cpp
@@ -14,6 +14,9 @@
 #include "Rendering/LightManager.hpp"
 #include "Rendering/Renderer.hpp"
 
+namespace kokko
+{
+
 const char* const EntityFactory::ComponentNames[] = {
 	"Transform",
 	"Render object",
@@ -173,4 +176,6 @@ const char* EntityFactory::GetComponentTypeName(size_t typeIndex)
 const char* EntityFactory::GetComponentTypeName(EntityComponentType component)
 {
 	return GetComponentTypeName(static_cast<size_t>(component));
+}
+
 }

--- a/engine/src/Engine/EntityFactory.hpp
+++ b/engine/src/Engine/EntityFactory.hpp
@@ -5,6 +5,9 @@
 class World;
 struct Entity;
 
+namespace kokko
+{
+
 enum class EntityComponentType
 {
 	Scene,
@@ -32,3 +35,5 @@ public:
 private:
 	static const char* const ComponentNames[ComponentTypeCount];
 };
+
+}

--- a/engine/src/Engine/World.cpp
+++ b/engine/src/Engine/World.cpp
@@ -63,7 +63,7 @@ World::World(AllocatorManager* allocManager,
 	scriptSystem.New(scriptSystem.allocator, inputManager);
 
 	terrainSystem.CreateScope(allocManager, "TerrainSystem", alloc);
-	terrainSystem.New(terrainSystem.allocator, renderDevice, resourceManagers.meshManager,
+	terrainSystem.New(terrainSystem.allocator, renderDevice,
 		resourceManagers.materialManager, resourceManagers.shaderManager);
 
 	particleSystem.CreateScope(allocManager, "ParticleEffects", alloc);

--- a/engine/src/Engine/World.hpp
+++ b/engine/src/Engine/World.hpp
@@ -27,10 +27,14 @@ class Renderer;
 class LightManager;
 class CameraSystem;
 class ScriptSystem;
-class TerrainSystem;
 class ParticleSystem;
 
 class ComponentSerializer;
+
+namespace kokko
+{
+class TerrainSystem;
+}
 
 class World
 {
@@ -64,7 +68,7 @@ public:
 	LightManager* GetLightManager() { return lightManager.instance; }
 	CameraSystem* GetCameraSystem() { return cameraSystem.instance; }
 	ScriptSystem* GetScriptSystem() { return scriptSystem.instance; }
-	TerrainSystem* GetTerrainSystem() { return terrainSystem.instance; }
+	kokko::TerrainSystem* GetTerrainSystem() { return terrainSystem.instance; }
 	ParticleSystem* GetParticleSystem() { return particleSystem.instance; }
 
 	LevelSerializer* GetSerializer() { return &levelSerializer; }
@@ -84,7 +88,7 @@ private:
 	InstanceAllocatorPair<Scene> scene;
 	InstanceAllocatorPair<Renderer> renderer;
 	InstanceAllocatorPair<ScriptSystem> scriptSystem;
-	InstanceAllocatorPair<TerrainSystem> terrainSystem;
+	InstanceAllocatorPair<kokko::TerrainSystem> terrainSystem;
 	InstanceAllocatorPair<ParticleSystem> particleSystem;
 
 	ResourceManagers resourceManagers;

--- a/engine/src/Graphics/ParticleSystem.cpp
+++ b/engine/src/Graphics/ParticleSystem.cpp
@@ -176,7 +176,7 @@ void ParticleSystem::RenderCustom(const RenderParams& params)
 
 		TransformUniformBlock transformUniforms;
 		transformUniforms.M = Mat4x4f();
-		transformUniforms.MV = params.viewport->view;
+		transformUniforms.MV = params.viewport->view.inverse;
 		transformUniforms.MVP = params.viewport->viewProjection;
 
 		renderDevice->BindBuffer(RenderBufferTarget::UniformBuffer, emitter.bufferIds[Buffer_RenderTransform]);

--- a/engine/src/Graphics/TerrainQuadTree.cpp
+++ b/engine/src/Graphics/TerrainQuadTree.cpp
@@ -8,6 +8,7 @@
 
 #include "Memory/Allocator.hpp"
 
+#include "Rendering/CameraParameters.hpp"
 #include "Rendering/RenderDevice.hpp"
 
 namespace kokko
@@ -90,6 +91,24 @@ void TerrainQuadTree::DestroyResources(Allocator* allocator, RenderDevice* rende
 
 	allocator->Deallocate(tiles);
 	allocator->Deallocate(tileTextureIds);
+}
+
+void TerrainQuadTree::GetTilesToRender(const CameraParameters& camera, Array<TerrainTileId>& resultOut)
+{
+	int currentLevel = treeLevels - 1;
+	int tilesPerDimension = GetTilesPerDimension(currentLevel);
+	resultOut.Reserve(tilesPerDimension * tilesPerDimension);
+	for (int y = 0; y < tilesPerDimension; ++y)
+	{
+		for (int x = 0; x < tilesPerDimension; ++x)
+		{
+			TerrainTileId& tile = resultOut.PushBack();
+
+			tile.level = currentLevel;
+			tile.x = x;
+			tile.y = y;
+		}
+	}
 }
 
 int TerrainQuadTree::GetLevelCount() const
@@ -193,20 +212,17 @@ void TerrainQuadTree::CreateTileTestData(TerrainTile& tile, int tileX, int tileY
 	}
 }
 
-TEST_CASE("TerrainQuadTree.CreateTileTestData")
-{
-	TerrainTile tileA, tileB;
-	
-	TerrainQuadTree::CreateTileTestData(tileA, 0, 0, 0.5f);
-	TerrainQuadTree::CreateTileTestData(tileB, 1, 0, 0.5f);
-
-	CHECK(tileA.heightData[TerrainTile::ResolutionWithBorder - 1] == tileB.heightData[0]);
-}
-
 uint16_t TerrainQuadTree::TestData(float x, float y)
 {
-	float normalized = 0.5f + std::sin(x * 0.12f) * 0.25f + std::sin(y * 0.12f) * 0.25f;
-	return static_cast<uint16_t>(normalized * UINT16_MAX);
+	float f = 0.01f;
+	float a = 0.12f;
+
+	float sum = 0.5f;
+	for (int i = 1; i <= 6; i += 5)
+	{
+		sum += std::sin(x * f * i) * a / i + std::sin(y * f * i) * a / i;
+	}
+	return static_cast<uint16_t>(sum * UINT16_MAX);
 }
 
 }

--- a/engine/src/Graphics/TerrainQuadTree.cpp
+++ b/engine/src/Graphics/TerrainQuadTree.cpp
@@ -161,7 +161,8 @@ void TerrainQuadTree::RenderTile(
 		Vec3f corner = Vec3f::Hadamard(tileBounds.extents, boxCorners[cornerIdx]);
 
 		Vec4f proj = vp * Vec4f(tileBounds.center + corner, 1.0f);
-		screenCoord = proj.xyz() * (1.0f / proj.w) * 0.5f + Vec3f(0.5f, 0.5f, 0.0f);
+		screenCoord = Vec3f::Hadamard(proj.xyz() * (1.0f / proj.w), Vec3f(0.5f, -0.5f, 0.5f)) +
+			Vec3f(0.5f, 0.5f, 0.5f);
 
 		min.x = std::min(screenCoord.x, min.x);
 		min.y = std::min(screenCoord.y, min.y);
@@ -170,9 +171,6 @@ void TerrainQuadTree::RenderTile(
 	}
 
 	Vec2f size(max.x - min.x, max.y - min.y);
-	
-
-	//float depth = Vec3f::Dot(center - eyePos, eyeForward);
 
 	float sizeMaxAxis = std::max(size.x, size.y);
 	bool tileIsSmallEnough = sizeMaxAxis < maximumSize;
@@ -185,19 +183,15 @@ void TerrainQuadTree::RenderTile(
 	{
 		resultOut.PushBack(id);
 
-		Vec3f translate;
-		translate.x = -halfTerrainSize + tileWidth * (id.x + 0.5f);
-		translate.y = 0.0f;
-		translate.z = -halfTerrainSize + tileWidth * (id.y + 0.5f);
+		Vec3f scale = tileSize;
+		scale.y = 0.0f;
 
-		Vec3f scale(tileWidth, 0.0f, tileWidth);
-
-		Mat4x4f transform = Mat4x4f::Translate(translate) * Mat4x4f::Scale(scale);
+		Mat4x4f transform = Mat4x4f::Translate(tileBounds.center) * Mat4x4f::Scale(scale);
 
 		vr->DrawWireCube(transform, col);
 
 		char buf[32];
-		auto [out, size] = fmt::format_to_n(buf, sizeof(buf), "{:.1f},{:.1f}", tileBounds.center.x, tileBounds.center.z);
+		auto [out, size] = fmt::format_to_n(buf, sizeof(buf), "{:.3f}", sizeMaxAxis);
 
 		tr->AddTextNormalized(StringRef(buf, size), screenCoord.xy());
 	}
@@ -321,11 +315,11 @@ void TerrainQuadTree::CreateTileTestData(TerrainTile& tile, int tileX, int tileY
 
 uint16_t TerrainQuadTree::TestData(float x, float y)
 {
-	float f = 0.1f;
+	float f = 0.02f;
 	float a = 0.12f;
 
 	float sum = 0.5f;
-	for (int i = 1; i <= 6; i += 5)
+	for (int i = 1; i <= 13; i += 6)
 	{
 		sum += std::sin(x * f * i) * a / i + std::sin(y * f * i) * a / i;
 	}

--- a/engine/src/Graphics/TerrainQuadTree.cpp
+++ b/engine/src/Graphics/TerrainQuadTree.cpp
@@ -1,0 +1,159 @@
+#include "Graphics/TerrainQuadTree.hpp"
+
+#include "doctest/doctest.h"
+
+#include "Memory/Allocator.hpp"
+
+#include "Rendering/RenderDevice.hpp"
+
+namespace kokko
+{
+
+TerrainQuadTree::TerrainQuadTree(Allocator* allocator, RenderDevice* renderDevice) :
+	allocator(allocator),
+	renderDevice(renderDevice),
+	tiles(nullptr),
+	tileTextureIds(nullptr),
+	treeLevels(0),
+	tileCount(0)
+{
+}
+
+TerrainQuadTree::~TerrainQuadTree()
+{
+	allocator->Deallocate(tileTextureIds);
+	allocator->Deallocate(tiles);
+}
+
+void TerrainQuadTree::Initialize(int levels)
+{
+	treeLevels = levels;
+	tileCount = GetTileCountForLevelCount(levels);
+
+	float terrainSize = 1024.0f;
+	float tileRes = static_cast<float>(TerrainTile::Resolution);
+	int tileResi = static_cast<int>(TerrainTile::Resolution);
+
+	void* buffer = allocator->Allocate(tileCount * sizeof(TerrainTile));
+	tiles = static_cast<TerrainTile*>(buffer);
+
+	for (int levelIdx = 0; levelIdx < treeLevels; ++levelIdx)
+	{
+		int tilesPerDimension = GetTilesPerDimension(levelIdx);
+
+		for (int tileY = 0; tileY < tilesPerDimension; ++tileY)
+		{
+			for (int tileX = 0; tileX < tilesPerDimension; ++tileX)
+			{
+				int tileIdx = GetTileIndex(levelIdx, tileX, tileY);
+				TerrainTile& tile = tiles[tileIdx];
+
+				for (int pixY = 0; pixY < TerrainTile::Resolution; ++pixY)
+				{
+					for (int pixX = 0; pixX < TerrainTile::Resolution; ++pixX)
+					{
+						float tileScale = terrainSize / tilesPerDimension;
+						float cx = (pixX / tileRes) * tileScale;
+						float cy = (pixY / tileRes) * tileScale;
+
+						float normalized = 0.5f + std::sin(cx * 0.031415f) * 0.25f + std::sin(cy * 0.031415f) * 0.25f;
+						uint16_t height = static_cast<uint16_t>(normalized * UINT16_MAX);
+
+						size_t pixelIndex = pixY * TerrainTile::Resolution + pixX;
+						tile.heightData[pixelIndex] = height;
+					}
+				}
+			}
+		}
+	}
+
+	tileTextureIds = static_cast<uint32_t*>(allocator->Allocate(tileCount * sizeof(uint32_t)));
+	renderDevice->CreateTextures(tileCount, tileTextureIds);
+
+	for (int levelIdx = 0; levelIdx < treeLevels; ++levelIdx)
+	{
+		int tilesPerDimension = GetTilesPerDimension(levelIdx);
+
+		for (int tileY = 0; tileY < tilesPerDimension; ++tileY)
+		{
+			for (int tileX = 0; tileX < tilesPerDimension; ++tileX)
+			{
+				int tileIdx = GetTileIndex(levelIdx, tileX, tileY);
+				
+				renderDevice->BindTexture(RenderTextureTarget::Texture2d, tileTextureIds[tileIdx]);
+
+				RenderCommandData::SetTextureStorage2D textureStorage{
+					RenderTextureTarget::Texture2d, 1, RenderTextureSizedFormat::R16,
+					tileResi, tileResi
+				};
+				renderDevice->SetTextureStorage2D(&textureStorage);
+
+				RenderCommandData::SetTextureSubImage2D subimage{
+					RenderTextureTarget::Texture2d, 0, 0, 0, tileResi, tileResi, RenderTextureBaseFormat::R,
+					RenderTextureDataType::UnsignedShort, tiles[tileIdx].heightData
+				};
+				renderDevice->SetTextureSubImage2D(&subimage);
+			}
+		}
+	}
+}
+
+int TerrainQuadTree::GetTilesPerDimension(int level)
+{
+	int levelSize = 1;
+
+	for (int i = 0; i < level; ++i)
+		levelSize *= 2;
+
+	return levelSize;
+}
+
+TEST_CASE("TerrainQuadTree.GetTilesPerDimension")
+{
+	CHECK(TerrainQuadTree::GetTilesPerDimension(0) == 1);
+	CHECK(TerrainQuadTree::GetTilesPerDimension(1) == 2);
+	CHECK(TerrainQuadTree::GetTilesPerDimension(2) == 4);
+	CHECK(TerrainQuadTree::GetTilesPerDimension(3) == 8);
+}
+
+int TerrainQuadTree::GetTileIndex(int level, int x, int y)
+{
+	int levelStart = 0;
+	int levelSize = 1;
+
+	for (int i = 0; i < level; ++i)
+	{
+		levelStart += levelSize * levelSize;
+		levelSize *= 2;
+	}
+
+	return levelStart + y * levelSize + x;
+}
+
+TEST_CASE("TerrainQuadTree.GetTileIndex")
+{
+	CHECK(TerrainQuadTree::GetTileIndex(0, 0, 0) == 0);
+	CHECK(TerrainQuadTree::GetTileIndex(1, 0, 0) == 1);
+	CHECK(TerrainQuadTree::GetTileIndex(1, 1, 0) == 2);
+	CHECK(TerrainQuadTree::GetTileIndex(1, 0, 1) == 3);
+	CHECK(TerrainQuadTree::GetTileIndex(1, 1, 1) == 4);
+	CHECK(TerrainQuadTree::GetTileIndex(2, 0, 0) == 5);
+	CHECK(TerrainQuadTree::GetTileIndex(2, 1, 0) == 6);
+	CHECK(TerrainQuadTree::GetTileIndex(2, 0, 1) == 9);
+	CHECK(TerrainQuadTree::GetTileIndex(3, 0, 0) == 21);
+}
+
+int TerrainQuadTree::GetTileCountForLevelCount(int levelCount)
+{
+	return GetTileIndex(levelCount, 0, 0);
+}
+
+TEST_CASE("TerrainQuadTree.GetTileCountForLevelCount")
+{
+	CHECK(TerrainQuadTree::GetTileCountForLevelCount(0) == 0);
+	CHECK(TerrainQuadTree::GetTileCountForLevelCount(1) == 1);
+	CHECK(TerrainQuadTree::GetTileCountForLevelCount(2) == 5);
+	CHECK(TerrainQuadTree::GetTileCountForLevelCount(3) == 21);
+}
+
+}

--- a/engine/src/Graphics/TerrainQuadTree.hpp
+++ b/engine/src/Graphics/TerrainQuadTree.hpp
@@ -3,8 +3,13 @@
 #include <cstddef>
 #include <cstdint>
 
+#include "Core/Array.hpp"
+
 class Allocator;
 class RenderDevice;
+
+struct CameraParameters;
+struct TerrainTileId;
 
 namespace kokko
 {
@@ -25,6 +30,8 @@ public:
 	void CreateResources(Allocator* allocator, RenderDevice* renderDevice, int levels);
 	void DestroyResources(Allocator* allocator, RenderDevice* renderDevice);
 
+	void GetTilesToRender(const CameraParameters& camera, Array<TerrainTileId>& resultOut);
+
 	int GetLevelCount() const;
 
 	const TerrainTile* GetTile(int level, int x, int y);
@@ -35,9 +42,8 @@ public:
 	static int GetTileCountForLevelCount(int levelCount);
 	static float GetTileScale(int level);
 
-	static void CreateTileTestData(TerrainTile& tile, int tileX, int tileY, float tileScale);
-
 private:
+	static void CreateTileTestData(TerrainTile& tile, int tileX, int tileY, float tileScale);
 
 	static uint16_t TestData(float x, float y);
 

--- a/engine/src/Graphics/TerrainQuadTree.hpp
+++ b/engine/src/Graphics/TerrainQuadTree.hpp
@@ -11,33 +11,38 @@ namespace kokko
 
 struct TerrainTile
 {
-	static const int Resolution = 64;
+	static constexpr int Resolution = 64;
 
-	unsigned int textureId;
 	uint16_t heightData[Resolution * Resolution];
 };
 
 class TerrainQuadTree
 {
 public:
-	TerrainQuadTree(Allocator* allocator, RenderDevice* renderDevice);
-	~TerrainQuadTree();
+	TerrainQuadTree();
 
-	void Initialize(int levels);
+	void CreateResources(Allocator* allocator, RenderDevice* renderDevice, int levels);
+	void DestroyResources(Allocator* allocator, RenderDevice* renderDevice);
+
+	int GetLevelCount() const;
+
+	const TerrainTile* GetTile(int level, int x, int y);
+	unsigned int GetTileHeightTexture(int level, int x, int y);
 
 	static int GetTilesPerDimension(int level);
 	static int GetTileIndex(int level, int x, int y);
 	static int GetTileCountForLevelCount(int levelCount);
 
 private:
-	Allocator* allocator;
-	RenderDevice* renderDevice;
+	static void CreateTileTestData(TerrainTile& tile, float tileScale);
+
+	static uint16_t TestData(float x, float y);
 
 	TerrainTile* tiles;
 	uint32_t* tileTextureIds;
 
 	int treeLevels;
-	size_t tileCount;
+	int tileCount;
 };
 
 }

--- a/engine/src/Graphics/TerrainQuadTree.hpp
+++ b/engine/src/Graphics/TerrainQuadTree.hpp
@@ -8,12 +8,15 @@
 class Allocator;
 class RenderDevice;
 
+struct FrustumPlanes;
 struct Mat4x4f;
 struct CameraParameters;
 struct TerrainTileId;
 
 namespace kokko
 {
+
+struct TerrainParameters;
 
 struct TerrainTile
 {
@@ -28,12 +31,23 @@ class TerrainQuadTree
 public:
 	TerrainQuadTree();
 
-	void CreateResources(Allocator* allocator, RenderDevice* renderDevice, int levels, float size);
+	void CreateResources(Allocator* allocator, RenderDevice* renderDevice, int levels,
+		const TerrainParameters& params);
 	void DestroyResources(Allocator* allocator, RenderDevice* renderDevice);
 
-	void GetTilesToRender(const Mat4x4f& viewProj, Array<TerrainTileId>& resultOut);
+	void GetTilesToRender(
+		const FrustumPlanes& frustum, const Mat4x4f& viewProj, Array<TerrainTileId>& resultOut);
 
 	int GetLevelCount() const;
+
+	float GetSize() const { return terrainWidth; }
+	void SetSize(float size) { terrainWidth = size; }
+
+	float GetBottom() const { return terrainBottom; }
+	void SetBottom(float bottom) { terrainBottom = bottom; }
+
+	float GetHeight() const { return terrainHeight; }
+	void SetHeight(float height) { terrainHeight = height; }
 
 	const TerrainTile* GetTile(int level, int x, int y);
 	unsigned int GetTileHeightTexture(int level, int x, int y);
@@ -44,7 +58,11 @@ public:
 	static float GetTileScale(int level);
 
 private:
-	void RenderTile(const TerrainTileId& id, const Mat4x4f& vp, Array<TerrainTileId>& resultOut);
+	void RenderTile(
+		const TerrainTileId& id,
+		const FrustumPlanes& frustum,
+		const Mat4x4f& vp,
+		Array<TerrainTileId>& resultOut);
 
 	static void CreateTileTestData(TerrainTile& tile, int tileX, int tileY, float tileScale);
 
@@ -55,7 +73,9 @@ private:
 
 	int treeLevels;
 	int tileCount;
-	float terrainSize;
+	float terrainWidth;
+	float terrainBottom;
+	float terrainHeight;
 };
 
 }

--- a/engine/src/Graphics/TerrainQuadTree.hpp
+++ b/engine/src/Graphics/TerrainQuadTree.hpp
@@ -8,6 +8,7 @@
 class Allocator;
 class RenderDevice;
 
+struct Mat4x4f;
 struct CameraParameters;
 struct TerrainTileId;
 
@@ -16,7 +17,7 @@ namespace kokko
 
 struct TerrainTile
 {
-	static constexpr int Resolution = 63;
+	static constexpr int Resolution = 31;
 	static constexpr int ResolutionWithBorder = Resolution + 1;
 
 	uint16_t heightData[ResolutionWithBorder * ResolutionWithBorder];
@@ -27,10 +28,10 @@ class TerrainQuadTree
 public:
 	TerrainQuadTree();
 
-	void CreateResources(Allocator* allocator, RenderDevice* renderDevice, int levels);
+	void CreateResources(Allocator* allocator, RenderDevice* renderDevice, int levels, float size);
 	void DestroyResources(Allocator* allocator, RenderDevice* renderDevice);
 
-	void GetTilesToRender(const CameraParameters& camera, Array<TerrainTileId>& resultOut);
+	void GetTilesToRender(const Mat4x4f& viewProj, Array<TerrainTileId>& resultOut);
 
 	int GetLevelCount() const;
 
@@ -43,6 +44,8 @@ public:
 	static float GetTileScale(int level);
 
 private:
+	void RenderTile(const TerrainTileId& id, const Mat4x4f& vp, Array<TerrainTileId>& resultOut);
+
 	static void CreateTileTestData(TerrainTile& tile, int tileX, int tileY, float tileScale);
 
 	static uint16_t TestData(float x, float y);
@@ -52,6 +55,7 @@ private:
 
 	int treeLevels;
 	int tileCount;
+	float terrainSize;
 };
 
 }

--- a/engine/src/Graphics/TerrainQuadTree.hpp
+++ b/engine/src/Graphics/TerrainQuadTree.hpp
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+class Allocator;
+class RenderDevice;
+
+namespace kokko
+{
+
+struct TerrainTile
+{
+	static const int Resolution = 64;
+
+	unsigned int textureId;
+	uint16_t heightData[Resolution * Resolution];
+};
+
+class TerrainQuadTree
+{
+public:
+	TerrainQuadTree(Allocator* allocator, RenderDevice* renderDevice);
+	~TerrainQuadTree();
+
+	void Initialize(int levels);
+
+	static int GetTilesPerDimension(int level);
+	static int GetTileIndex(int level, int x, int y);
+	static int GetTileCountForLevelCount(int levelCount);
+
+private:
+	Allocator* allocator;
+	RenderDevice* renderDevice;
+
+	TerrainTile* tiles;
+	uint32_t* tileTextureIds;
+
+	int treeLevels;
+	size_t tileCount;
+};
+
+}

--- a/engine/src/Graphics/TerrainQuadTree.hpp
+++ b/engine/src/Graphics/TerrainQuadTree.hpp
@@ -11,9 +11,10 @@ namespace kokko
 
 struct TerrainTile
 {
-	static constexpr int Resolution = 64;
+	static constexpr int Resolution = 63;
+	static constexpr int ResolutionWithBorder = Resolution + 1;
 
-	uint16_t heightData[Resolution * Resolution];
+	uint16_t heightData[ResolutionWithBorder * ResolutionWithBorder];
 };
 
 class TerrainQuadTree
@@ -32,9 +33,11 @@ public:
 	static int GetTilesPerDimension(int level);
 	static int GetTileIndex(int level, int x, int y);
 	static int GetTileCountForLevelCount(int levelCount);
+	static float GetTileScale(int level);
+
+	static void CreateTileTestData(TerrainTile& tile, int tileX, int tileY, float tileScale);
 
 private:
-	static void CreateTileTestData(TerrainTile& tile, float tileScale);
 
 	static uint16_t TestData(float x, float y);
 

--- a/engine/src/Graphics/TerrainSerializer.hpp
+++ b/engine/src/Graphics/TerrainSerializer.hpp
@@ -14,7 +14,7 @@
 class TerrainSerializer final : public ComponentSerializer
 {
 public:
-	TerrainSerializer(TerrainSystem* terrainSystem) :
+	TerrainSerializer(kokko::TerrainSystem* terrainSystem) :
 		terrainSystem(terrainSystem)
 	{
 	}
@@ -26,15 +26,11 @@ public:
 
 	virtual void DeserializeComponent(const YAML::Node& map, Entity entity) override
 	{
-		TerrainParameters terrain;
+		kokko::TerrainParameters terrain;
 
 		YAML::Node sizeNode = map["terrain_size"];
 		if (sizeNode.IsDefined() && sizeNode.IsScalar())
 			terrain.terrainSize = sizeNode.as<float>();
-
-		YAML::Node resNode = map["terrain_resolution"];
-		if (resNode.IsDefined() && resNode.IsScalar())
-			terrain.terrainResolution = resNode.as<int>();
 
 		YAML::Node scaleNode = map["texture_scale"];
 		if (scaleNode.IsDefined() && scaleNode.IsSequence())
@@ -48,25 +44,23 @@ public:
 		if (maxNode.IsDefined() && maxNode.IsScalar())
 			terrain.maxHeight = maxNode.as<float>();
 
-		TerrainId id = terrainSystem->AddTerrain(entity, terrain);
+		kokko::TerrainId id = terrainSystem->AddTerrain(entity, terrain);
 	}
 
 	virtual void SerializeComponent(YAML::Emitter& out, Entity entity) override
 	{
-		TerrainId terrainId = terrainSystem->Lookup(entity);
-		if (terrainId != TerrainId::Null)
+		kokko::TerrainId terrainId = terrainSystem->Lookup(entity);
+		if (terrainId != kokko::TerrainId::Null)
 		{
 			out << YAML::BeginMap;
 			out << YAML::Key << GetComponentTypeKey() << YAML::Value << "terrain";
 
-			int resolution = terrainSystem->GetResolution(terrainId);
 			float size = terrainSystem->GetSize(terrainId);
 			float minHeight = terrainSystem->GetMinHeight(terrainId);
 			float maxHeight = terrainSystem->GetMaxHeight(terrainId);
 			Vec2f textureScale = terrainSystem->GetTextureScale(terrainId);
 
 			out << YAML::Key << "terrain_size" << YAML::Value << size;
-			out << YAML::Key << "terrain_resolution" << YAML::Value << resolution;
 			out << YAML::Key << "texture_scale" << YAML::Value << textureScale;
 			out << YAML::Key << "min_height" << YAML::Value << minHeight;
 			out << YAML::Key << "max_height" << YAML::Value << maxHeight;
@@ -76,5 +70,5 @@ public:
 	}
 
 private:
-	TerrainSystem* terrainSystem;
+	kokko::TerrainSystem* terrainSystem;
 };

--- a/engine/src/Graphics/TerrainSerializer.hpp
+++ b/engine/src/Graphics/TerrainSerializer.hpp
@@ -36,13 +36,13 @@ public:
 		if (scaleNode.IsDefined() && scaleNode.IsSequence())
 			terrain.textureScale = scaleNode.as<Vec2f>();
 
-		YAML::Node minNode = map["min_height"];
+		YAML::Node minNode = map["terrain_bottom"];
 		if (minNode.IsDefined() && minNode.IsScalar())
-			terrain.minHeight = minNode.as<float>();
+			terrain.heightOrigin = minNode.as<float>();
 
-		YAML::Node maxNode = map["max_height"];
+		YAML::Node maxNode = map["terrain_height"];
 		if (maxNode.IsDefined() && maxNode.IsScalar())
-			terrain.maxHeight = maxNode.as<float>();
+			terrain.heightRange = maxNode.as<float>();
 
 		kokko::TerrainId id = terrainSystem->AddTerrain(entity, terrain);
 	}
@@ -56,14 +56,14 @@ public:
 			out << YAML::Key << GetComponentTypeKey() << YAML::Value << "terrain";
 
 			float size = terrainSystem->GetSize(terrainId);
-			float minHeight = terrainSystem->GetMinHeight(terrainId);
-			float maxHeight = terrainSystem->GetMaxHeight(terrainId);
+			float heightOrigin = terrainSystem->GetBottom(terrainId);
+			float heightRange = terrainSystem->GetHeight(terrainId);
 			Vec2f textureScale = terrainSystem->GetTextureScale(terrainId);
 
 			out << YAML::Key << "terrain_size" << YAML::Value << size;
 			out << YAML::Key << "texture_scale" << YAML::Value << textureScale;
-			out << YAML::Key << "min_height" << YAML::Value << minHeight;
-			out << YAML::Key << "max_height" << YAML::Value << maxHeight;
+			out << YAML::Key << "terrain_bottom" << YAML::Value << heightOrigin;
+			out << YAML::Key << "terrain_height" << YAML::Value << heightRange;
 
 			out << YAML::EndMap;
 		}

--- a/engine/src/Graphics/TerrainSystem.cpp
+++ b/engine/src/Graphics/TerrainSystem.cpp
@@ -50,6 +50,7 @@ TerrainSystem::TerrainSystem(
 	meshManager(meshManager),
 	materialManager(materialManager),
 	shaderManager(shaderManager),
+	quadTree(allocator, renderDevice),
 	terrainMaterial(MaterialId::Null),
 	entityMap(allocator)
 {
@@ -67,6 +68,8 @@ TerrainSystem::~TerrainSystem()
 void TerrainSystem::Initialize()
 {
 	KOKKO_PROFILE_FUNCTION();
+
+	quadTree.Initialize(4);
 
 	StringRef path("engine/materials/deferred_geometry/terrain.material.json");
 	terrainMaterial = materialManager->GetIdByPath(path);

--- a/engine/src/Graphics/TerrainSystem.cpp
+++ b/engine/src/Graphics/TerrainSystem.cpp
@@ -358,25 +358,9 @@ void TerrainSystem::RenderTerrain(TerrainId id, const MaterialData& material, co
 	KOKKO_PROFILE_FUNCTION();
 
 	// Select tiles to render
-	// TODO: Add method to quadtree to select render tiles based on camera parameters
 
 	TerrainQuadTree& quadTree = data.resource[id.i].quadTree;
-	int levels = quadTree.GetLevelCount();
-	int currentLevel = levels - 1;
-	int tilesPerDimension = TerrainQuadTree::GetTilesPerDimension(currentLevel);
-
-	tilesToRender.Reserve(tilesPerDimension * tilesPerDimension);
-	for (int y = 0; y < tilesPerDimension; ++y)
-	{
-		for (int x = 0; x < tilesPerDimension; ++x)
-		{
-			RenderTile& tile = tilesToRender.PushBack();
-			
-			tile.level = currentLevel;
-			tile.x = x;
-			tile.y = y;
-		}
-	}
+	quadTree.GetTilesToRender(CameraParameters(), tilesToRender);
 
 	// Update uniform buffer
 
@@ -395,7 +379,6 @@ void TerrainSystem::RenderTerrain(TerrainId id, const MaterialData& material, co
 
 	uniformStagingBuffer.Resize(tilesToRender.GetCount() * uniformBlockStride);
 
-	float halfTileCount = tilesPerDimension * 0.5f;
 	int blocksWritten = 0;
 	for (const auto& tile : tilesToRender)
 	{

--- a/engine/src/Graphics/TerrainSystem.hpp
+++ b/engine/src/Graphics/TerrainSystem.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
 #include <cstddef>
+#include <cstdint>
 
+#include "Core/Array.hpp"
 #include "Core/HashMap.hpp"
 
 #include "Graphics/TerrainQuadTree.hpp"
@@ -76,10 +78,15 @@ public:
 	virtual void RenderCustom(const CustomRenderer::RenderParams& params) override final;
 
 private:
+	static constexpr int TileLevels = 4;
+
 	Allocator* allocator;
 	RenderDevice* renderDevice;
 	MaterialManager* materialManager;
 	ShaderManager* shaderManager;
+	
+	unsigned int uniformBlockStride;
+	unsigned int uniformBufferId;
 
 	MaterialId terrainMaterial;
 
@@ -95,10 +102,10 @@ private:
 	};
 	VertexData vertexData;
 
+	unsigned int textureSampler;
+
 	struct ResourceData
 	{
-		unsigned int uniformBufferId;
-
 		kokko::TerrainQuadTree quadTree;
 	};
 
@@ -113,6 +120,17 @@ private:
 		ResourceData* resource;
 	}
 	data;
+
+	struct RenderTile
+	{
+		int level;
+		int x;
+		int y;
+	};
+
+	Array<RenderTile> tilesToRender;
+
+	Array<uint8_t> uniformStagingBuffer;
 
 	void CreateVertexData();
 

--- a/engine/src/Graphics/TerrainSystem.hpp
+++ b/engine/src/Graphics/TerrainSystem.hpp
@@ -21,6 +21,9 @@ class Renderer;
 struct Entity;
 struct MaterialData;
 
+namespace kokko
+{
+
 struct TerrainId
 {
 	unsigned int i;
@@ -33,7 +36,6 @@ struct TerrainId
 
 struct TerrainParameters
 {
-	int terrainResolution = 128;
 	float terrainSize = 64.0f;
 	Vec2f textureScale = Vec2f(0.25f, 0.25f);
 	float minHeight = -0.10f;
@@ -44,7 +46,7 @@ class TerrainSystem : public CustomRenderer
 {
 public:
 	TerrainSystem(Allocator* allocator, RenderDevice* renderDevice,
-		MeshManager* meshManager, MaterialManager* materialManager, ShaderManager* shaderManager);
+		MaterialManager * materialManager, ShaderManager* shaderManager);
 	~TerrainSystem();
 
 	void Initialize();
@@ -55,8 +57,6 @@ public:
 	void RemoveTerrain(TerrainId id);
 
 	void RemoveAll();
-
-	int GetResolution(TerrainId id) const { return data.param[id.i].terrainResolution; }
 
 	float GetSize(TerrainId id) const { return data.param[id.i].terrainSize; }
 	void SetSize(TerrainId id, float size) { data.param[id.i].terrainSize = size; }
@@ -78,29 +78,34 @@ public:
 private:
 	Allocator* allocator;
 	RenderDevice* renderDevice;
-	MeshManager* meshManager;
 	MaterialManager* materialManager;
 	ShaderManager* shaderManager;
-
-	kokko::TerrainQuadTree quadTree;
 
 	MaterialId terrainMaterial;
 
 	HashMap<unsigned int, TerrainId> entityMap;
 
+	struct VertexData
+	{
+		unsigned int vertexArray;
+		unsigned int vertexBuffer;
+		unsigned int indexBuffer;
+
+		int indexCount;
+	};
+	VertexData vertexData;
+
 	struct ResourceData
 	{
-		unsigned int vertexArrayId;
 		unsigned int uniformBufferId;
-		unsigned int textureId;
-		MeshId meshId;
-		uint16_t* heightData;
+
+		kokko::TerrainQuadTree quadTree;
 	};
 
 	struct InstanceData
 	{
-		unsigned int count;
-		unsigned int allocated;
+		size_t count;
+		size_t allocated;
 		void* buffer;
 
 		Entity* entity;
@@ -109,6 +114,8 @@ private:
 	}
 	data;
 
+	void CreateVertexData();
+
 	void InitializeTerrain(TerrainId id);
 	void DeinitializeTerrain(TerrainId id);
 
@@ -116,3 +123,5 @@ private:
 
 	void RenderTerrain(TerrainId id, const MaterialData& material, const RenderViewport& viewport);
 };
+
+}

--- a/engine/src/Graphics/TerrainSystem.hpp
+++ b/engine/src/Graphics/TerrainSystem.hpp
@@ -4,11 +4,12 @@
 
 #include "Core/HashMap.hpp"
 
-#include "Graphics/TerrainInstance.hpp"
+#include "Graphics/TerrainQuadTree.hpp"
 
 #include "Rendering/CustomRenderer.hpp"
 
 #include "Resources/MaterialData.hpp"
+#include "Resources/MeshData.hpp"
 
 class Allocator;
 class RenderDevice;
@@ -80,6 +81,8 @@ private:
 	MeshManager* meshManager;
 	MaterialManager* materialManager;
 	ShaderManager* shaderManager;
+
+	kokko::TerrainQuadTree quadTree;
 
 	MaterialId terrainMaterial;
 

--- a/engine/src/Graphics/TerrainSystem.hpp
+++ b/engine/src/Graphics/TerrainSystem.hpp
@@ -79,8 +79,6 @@ public:
 	virtual void RenderCustom(const CustomRenderer::RenderParams& params) override final;
 
 private:
-	static constexpr int TileLevels = 4;
-
 	Allocator* allocator;
 	RenderDevice* renderDevice;
 	MaterialManager* materialManager;

--- a/engine/src/Graphics/TerrainSystem.hpp
+++ b/engine/src/Graphics/TerrainSystem.hpp
@@ -41,8 +41,8 @@ struct TerrainParameters
 {
 	float terrainSize = 64.0f;
 	Vec2f textureScale = Vec2f(0.25f, 0.25f);
-	float minHeight = -0.10f;
-	float maxHeight = 0.10f;
+	float heightOrigin = -1.0f;
+	float heightRange = 2.0f;
 };
 
 class TerrainSystem : public CustomRenderer
@@ -61,17 +61,17 @@ public:
 
 	void RemoveAll();
 
-	float GetSize(TerrainId id) const { return data.param[id.i].terrainSize; }
-	void SetSize(TerrainId id, float size) { data.param[id.i].terrainSize = size; }
+	float GetSize(TerrainId id) const { return data.quadTree[id.i].GetSize(); }
+	void SetSize(TerrainId id, float size) { data.quadTree[id.i].SetSize(size); }
 
-	float GetMinHeight(TerrainId id) const { return data.param[id.i].minHeight; }
-	void SetMinHeight(TerrainId id, float minHeight) { data.param[id.i].minHeight = minHeight; }
+	float GetBottom(TerrainId id) const { return data.quadTree[id.i].GetBottom(); }
+	void SetBottom(TerrainId id, float bottom) { data.quadTree[id.i].SetBottom(bottom); }
 
-	float GetMaxHeight(TerrainId id) const { return data.param[id.i].maxHeight; }
-	void SetMaxHeight(TerrainId id, float maxHeight) { data.param[id.i].maxHeight = maxHeight; }
+	float GetHeight(TerrainId id) const { return data.quadTree[id.i].GetHeight(); }
+	void SetHeight(TerrainId id, float height) { data.quadTree[id.i].SetHeight(height); }
 
-	Vec2f GetTextureScale(TerrainId id) const { return data.param[id.i].textureScale; }
-	void SetTextureScale(TerrainId id, Vec2f scale) { data.param[id.i].textureScale = scale; }
+	Vec2f GetTextureScale(TerrainId id) const { return data.textureScale[id.i]; }
+	void SetTextureScale(TerrainId id, Vec2f scale) { data.textureScale[id.i] = scale; }
 
 	void RegisterCustomRenderer(Renderer* renderer);
 
@@ -103,11 +103,6 @@ private:
 
 	unsigned int textureSampler;
 
-	struct ResourceData
-	{
-		kokko::TerrainQuadTree quadTree;
-	};
-
 	struct InstanceData
 	{
 		size_t count;
@@ -115,8 +110,8 @@ private:
 		void* buffer;
 
 		Entity* entity;
-		TerrainParameters* param;
-		ResourceData* resource;
+		Vec2f* textureScale;
+		TerrainQuadTree* quadTree;
 	}
 	data;
 
@@ -126,7 +121,7 @@ private:
 
 	void CreateVertexData();
 
-	void InitializeTerrain(TerrainId id);
+	void InitializeTerrain(TerrainId id, const TerrainParameters& params);
 	void DeinitializeTerrain(TerrainId id);
 
 	void Reallocate(size_t required);

--- a/engine/src/Graphics/TerrainSystem.hpp
+++ b/engine/src/Graphics/TerrainSystem.hpp
@@ -7,6 +7,7 @@
 #include "Core/HashMap.hpp"
 
 #include "Graphics/TerrainQuadTree.hpp"
+#include "Graphics/TerrainTileId.hpp"
 
 #include "Rendering/CustomRenderer.hpp"
 
@@ -121,14 +122,7 @@ private:
 	}
 	data;
 
-	struct RenderTile
-	{
-		int level;
-		int x;
-		int y;
-	};
-
-	Array<RenderTile> tilesToRender;
+	Array<TerrainTileId> tilesToRender;
 
 	Array<uint8_t> uniformStagingBuffer;
 

--- a/engine/src/Graphics/TerrainTileId.hpp
+++ b/engine/src/Graphics/TerrainTileId.hpp
@@ -1,0 +1,8 @@
+#pragma once
+
+struct TerrainTileId
+{
+	int level;
+	int x;
+	int y;
+};

--- a/engine/src/Math/Intersect3D.cpp
+++ b/engine/src/Math/Intersect3D.cpp
@@ -10,7 +10,31 @@
 #include "Math/Mat4x4.hpp"
 #include "Math/Vec2.hpp"
 
-void Intersect::FrustumAABB(
+bool Intersect::FrustumAabb(const FrustumPlanes& frustum, const BoundingBox& bounds)
+{
+	KOKKO_PROFILE_FUNCTION();
+
+	// For each plane in view frustum
+	for (unsigned int planeIdx = 0; planeIdx < 6; ++planeIdx)
+	{
+		Vec3f planeNormalAbs(
+			std::abs(frustum.planes[planeIdx].normal.x),
+			std::abs(frustum.planes[planeIdx].normal.y),
+			std::abs(frustum.planes[planeIdx].normal.z));
+
+		const float d = Vec3f::Dot(bounds.center, frustum.planes[planeIdx].normal);
+		const float r = Vec3f::Dot(bounds.extents, planeNormalAbs);
+
+		if (d + r < -frustum.planes[planeIdx].distance)
+		{
+			return false;
+		}
+	}
+
+	return true;
+}
+
+void Intersect::FrustumAabbN(
 	const FrustumPlanes& frustum,
 	unsigned int count,
 	const BoundingBox* bounds,

--- a/engine/src/Math/Intersect3D.hpp
+++ b/engine/src/Math/Intersect3D.hpp
@@ -10,9 +10,16 @@ struct BitPack;
 namespace Intersect
 {
 	/*
+	* Calculate visibility for a single bounding box
+	*/
+	bool FrustumAabb(
+	const FrustumPlanes& frustum,
+	const BoundingBox& bounds);
+
+	/*
 	* Calculate visibility for bounding boxes
 	*/
-	void FrustumAABB(
+	void FrustumAabbN(
 		const FrustumPlanes& frustum,
 		unsigned int count,
 		const BoundingBox* bounds,

--- a/engine/src/Rendering/RenderViewport.hpp
+++ b/engine/src/Rendering/RenderViewport.hpp
@@ -14,8 +14,7 @@ struct RenderViewport
 	float minusNear;
 	float objectMinScreenSizePx;
 
-	Mat4x4f viewToWorld;
-	Mat4x4f view;
+	Mat4x4fBijection view;
 	Mat4x4f projection;
 	Mat4x4f viewProjection;
 

--- a/engine/src/Resources/MeshManager.cpp
+++ b/engine/src/Resources/MeshManager.cpp
@@ -418,4 +418,3 @@ void MeshManager::UploadIndexed(MeshId id, const IndexedVertexData& vdata)
 	CreateDrawDataIndexed(index, vdata);
 	SetVertexAttribPointers(vdata.vertexFormat);
 }
-

--- a/engine/src/System/Window.cpp
+++ b/engine/src/System/Window.cpp
@@ -117,6 +117,11 @@ void Window::UpdateInput()
 
 void Window::ProcessEvents()
 {
+	{
+		KOKKO_PROFILE_SCOPE("glfwPollEvents()");
+		glfwPollEvents();
+	}
+
 	if (framebufferResizePending)
 	{
 		for (auto& callback : framebufferResizeCallbacks)
@@ -131,10 +136,6 @@ void Window::Swap()
 	{
 		KOKKO_PROFILE_SCOPE("glfwSwapBuffers()");
 		glfwSwapBuffers(windowHandle);
-	}
-	{
-		KOKKO_PROFILE_SCOPE("glfwPollEvents()");
-		glfwPollEvents();
 	}
 }
 


### PR DESCRIPTION
- Use quadtree to manage terrain tiles at different LODs
- Currently the LOD is selected based on the size of each tile on screen
- All tiles are loaded and uploaded to the GPU at terrain initialization