### PR TITLE
Level save improvements

### DIFF
--- a/editor/src/AssetBrowserView.cpp
+++ b/editor/src/AssetBrowserView.cpp
@@ -18,7 +18,7 @@ namespace editor
 AssetBrowserView::AssetBrowserView(Allocator* allocator) :
 	EditorWindow("Asset Browser"),
 	allocator(allocator),
-	currentVirtualPath(EditorConstants::VirtualPathAssets),
+	currentVirtualPath(EditorConstants::VirtualMountAssets),
 	editorImages(nullptr),
 	pathStore(allocator)
 {
@@ -55,7 +55,7 @@ void AssetBrowserView::Update(EditorContext& context)
 			{
 				const fs::path& root = context.project->GetAssetPath();
 
-				if (ImGui::Button("Go to parent") && currentDirectory != root)
+				if (ImGui::Button("Go to parent"))
 				{
 					MoveToPath(context, currentDirectory.parent_path());
 				}
@@ -184,7 +184,8 @@ void AssetBrowserView::DrawEntry(
 
 				if (auto asset = context.assetLibrary->FindAssetByVirtualPath(ConvertPath(relativePath)))
 				{
-					ImGui::SetDragDropPayload(EditorConstants::AssetDragDropType, &asset->uid, sizeof(Uid));
+					Uid uid = asset->GetUid();
+					ImGui::SetDragDropPayload(EditorConstants::AssetDragDropType, &uid, sizeof(Uid));
 
 					ImGui::Text("%s", fileStr.c_str());
 				}
@@ -224,10 +225,15 @@ void AssetBrowserView::SelectPath(EditorContext& context, const std::filesystem:
 
 		if (asset != nullptr)
 		{
-			context.selectedAsset = asset->uid;
+			context.selectedAsset = asset->GetUid();
 
 			if (editAsset)
-				context.editingAsset = asset->uid;
+			{
+				if (asset->GetType() == AssetType::Level)
+					context.requestLoadLevel = asset->GetUid();
+				else
+					context.editingAsset = asset->GetUid();
+			}
 
 			return;
 		}

--- a/editor/src/AssetLibrary.hpp
+++ b/editor/src/AssetLibrary.hpp
@@ -21,20 +21,36 @@ class EditorProject;
 
 enum class AssetType
 {
+	Level,
 	Material,
 	Shader,
 	Texture
 };
 
-struct AssetInfo
+class AssetInfo
 {
-	StringRef virtualPath;
-	String filePath;
+public:
+	AssetInfo(Allocator* allocator, StringRef virtualMount, StringRef relativePath,
+		Uid uid, uint64_t contentHash, AssetType type);
+
+	const String& GetVirtualPath() const { return virtualPath; }
+	StringRef GetFilename() const { return filename; }
+	Uid GetUid() const { return uid; }
+	AssetType GetType() const { return type; }
+
+private:
+	friend class AssetLibrary;
+
+	// Holds complete virtual path, lower members are referencing parts of this string
+	String virtualPath;
+
+	StringRef virtualMount;
+	StringRef pathRelativeToMount;
+	StringRef filename;
+
 	Uid uid;
 	uint64_t contentHash;
 	AssetType type;
-
-	String GetVirtualPath() const;
 };
 
 class AssetLibrary
@@ -46,7 +62,8 @@ public:
 	const AssetInfo* FindAssetByUid(const Uid& uid);
 	const AssetInfo* FindAssetByVirtualPath(const String& virtualPath);
 
-	bool UpdateAssetContent(const Uid& uid, ArrayView<const char> content);
+	Optional<Uid> CreateAsset(AssetType type, StringRef pathRelativeToAssets, ArrayView<const uint8_t> content);
+	bool UpdateAssetContent(const Uid& uid, ArrayView<const uint8_t> content);
 
 	void ScanEngineAssets();
 	void SetProject(const EditorProject* project);

--- a/editor/src/AssetView.hpp
+++ b/editor/src/AssetView.hpp
@@ -20,7 +20,7 @@ struct TextureUniform;
 namespace editor
 {
 
-struct AssetInfo;
+class AssetInfo;
 
 class AssetView : public EditorWindow
 {

--- a/editor/src/EditorApp.hpp
+++ b/editor/src/EditorApp.hpp
@@ -18,6 +18,9 @@ struct EngineSettings;
 
 namespace kokko
 {
+
+struct Uid;
+
 namespace editor
 {
 
@@ -56,7 +59,6 @@ private:
 		None,
 		CreateProject,
 		OpenProject,
-		OpenLevel,
 		SaveLevelAs
 	};
 
@@ -82,7 +84,7 @@ private:
 	bool exitRequested;
 
 	MainMenuDialog currentMainMenuDialog;
-	uint32_t currentDialogId;
+	uint64_t currentDialogId;
 };
 
 }

--- a/editor/src/EditorAssetLoader.cpp
+++ b/editor/src/EditorAssetLoader.cpp
@@ -35,7 +35,7 @@ Optional<Uid> EditorAssetLoader::GetAssetUidByVirtualPath(const StringRef& path)
 	pathString.Assign(path);
 
 	if (auto asset = assetLibrary->FindAssetByVirtualPath(pathString))
-		return asset->uid;
+		return asset->GetUid();
 
 	return Optional<Uid>();
 }

--- a/editor/src/EditorConstants.cpp
+++ b/editor/src/EditorConstants.cpp
@@ -12,9 +12,9 @@ const char* const EditorConstants::AssetDirectoryName = "Assets";
 const char* const EditorConstants::EngineResourcePath = "engine/res";
 const char* const EditorConstants::EditorResourcePath = "editor/res";
 
-const char* const EditorConstants::VirtualPathEngine = "engine";
-const char* const EditorConstants::VirtualPathEditor = "editor";
-const char* const EditorConstants::VirtualPathAssets = "assets";
+const char* const EditorConstants::VirtualMountEngine = "engine";
+const char* const EditorConstants::VirtualMountEditor = "editor";
+const char* const EditorConstants::VirtualMountAssets = "assets";
 
 const char* const EditorConstants::UserSettingsFilePath = "editor_user_settings.yml";
 

--- a/editor/src/EditorConstants.hpp
+++ b/editor/src/EditorConstants.hpp
@@ -22,9 +22,9 @@ public:
 
 	// Virtual filesystem
 
-	static const char* const VirtualPathEngine;
-	static const char* const VirtualPathEditor;
-	static const char* const VirtualPathAssets;
+	static const char* const VirtualMountEngine;
+	static const char* const VirtualMountEditor;
+	static const char* const VirtualMountAssets;
 
 	// Editor settings
 

--- a/editor/src/EditorContext.hpp
+++ b/editor/src/EditorContext.hpp
@@ -28,6 +28,9 @@ struct EditorContext
 	EngineSettings* engineSettings;
 	Entity selectedEntity;
 
+	Optional<Uid> loadedLevel;
+	Optional<Uid> requestLoadLevel;
+
 	Optional<Uid> selectedAsset;
 	Optional<Uid> editingAsset;
 

--- a/editor/src/EditorCore.hpp
+++ b/editor/src/EditorCore.hpp
@@ -1,6 +1,9 @@
 #pragma once
 
+#include <filesystem>
+
 #include "Core/Array.hpp"
+#include "Core/Optional.hpp"
 #include "Core/String.hpp"
 
 #include "FilePickerDialog.hpp"
@@ -20,6 +23,9 @@ struct EngineSettings;
 
 namespace kokko
 {
+
+struct Uid;
+
 namespace editor
 {
 
@@ -42,6 +48,7 @@ public:
 	ArrayView<EditorWindow*> GetWindows();
 
 	AssetLibrary* GetAssetLibrary();
+	Optional<Uid> GetLoadedLevelUid() const;
 
 	void NotifyProjectChanged(const EditorProject* editorProject);
 
@@ -49,11 +56,15 @@ public:
 	void LateUpdate();
 	void EndFrame();
 
+	void OpenLevel(Uid levelAssetUid);
+	void SaveLevelAs(const std::filesystem::path& pathRelativeToAssets);
+
 	void CopyEntity();
 	void PasteEntity();
 
 private:
 	Allocator* allocator;
+	Filesystem* filesystem;
 	EditorContext editorContext;
 	EditorImages images;
 

--- a/editor/src/EditorUserSettings.hpp
+++ b/editor/src/EditorUserSettings.hpp
@@ -2,6 +2,9 @@
 
 #include <filesystem>
 
+#include "Core/Optional.hpp"
+#include "Core/Uid.hpp"
+
 namespace kokko
 {
 namespace editor
@@ -10,6 +13,7 @@ namespace editor
 struct EditorUserSettings
 {
 	std::filesystem::path lastOpenedProject;
+	Optional<Uid> lastOpenedLevel;
 
 	bool SerializeToFile(const char* filePath);
 	bool DeserializeFromFile(const char* filePath);

--- a/editor/src/EntityListView.cpp
+++ b/editor/src/EntityListView.cpp
@@ -8,6 +8,7 @@
 #include "Engine/EntityManager.hpp"
 #include "Engine/World.hpp"
 
+#include "AssetLibrary.hpp"
 #include "EditorConstants.hpp"
 #include "EditorContext.hpp"
 
@@ -43,10 +44,20 @@ void EntityListView::Update(EditorContext& context)
 				EntityManager* entityManager = world->GetEntityManager();
 				Scene* scene = world->GetScene();
 
+				context.temporaryString.Assign("Unnamed level");
+				if (context.loadedLevel.HasValue())
+				{
+					auto levelAsset = context.assetLibrary->FindAssetByUid(context.loadedLevel.GetValue());
+					if (levelAsset != nullptr)
+					{
+						context.temporaryString.Assign(levelAsset->GetFilename());
+					}
+				}
+
 				ImGuiTreeNodeFlags levelNodeFlags = ImGuiTreeNodeFlags_SpanAvailWidth |
 					ImGuiTreeNodeFlags_CollapsingHeader | ImGuiTreeNodeFlags_DefaultOpen;
 
-				if (ImGui::TreeNodeEx(world->GetLoadedLevelFilename().GetCStr(), levelNodeFlags))
+				if (ImGui::TreeNodeEx(context.temporaryString.GetCStr(), levelNodeFlags))
 				{
 					ProcessSceneDragDropTarget(SceneObjectId::Null);
 

--- a/editor/src/FilePickerDialog.hpp
+++ b/editor/src/FilePickerDialog.hpp
@@ -11,9 +11,26 @@ namespace editor
 class FilePickerDialog
 {
 public:
-	FilePickerDialog();
+	enum class Type
+	{
+		FileOpen,
+		FileSave,
+		FolderOpen,
+	};
 
-	static FilePickerDialog* Get();
+	struct Descriptor
+	{
+		const char* popupTitle;
+		const char* descriptionText;
+		const char* actionButtonText;
+
+		Type dialogType;
+
+		bool relativeToAssetPath;
+		std::filesystem::path assetPath;
+	};
+
+	FilePickerDialog();
 
 	void Update();
 
@@ -22,38 +39,25 @@ public:
 	* If true, parameter pathOut is assigned the selected path, or an empty string,
 	* if the dialog was cancelled.
 	*/
-	bool GetDialogResult(uint32_t id, std::filesystem::path& pathOut);
+	bool GetDialogResult(uint64_t id, std::filesystem::path& pathOut);
 
-	uint32_t StartDialogFileOpen(const char* popupTitle, const char* actionText);
-	uint32_t StartDialogFileSave(const char* popupTitle, const char* actionText);
-	uint32_t StartDialogFolderOpen(const char* popupTitle, const char* actionText);
+	uint64_t StartDialog(const Descriptor& descriptor);
 
 private:
-	enum class DialogType
-	{
-		None,
-		FileOpen,
-		FileSave,
-		FolderOpen,
-	};
+	void CloseDialog(bool canceled);
 
-	uint32_t StartDialogInternal(const char* title, const char* action, DialogType type);
-
-	static FilePickerDialog* singletonInstance;
+	std::filesystem::path ConvertPath(const std::filesystem::path& path);
 
 	std::filesystem::path currentPath;
 	std::filesystem::path selectedFilePath;
 
 	bool dialogClosed;
-	uint32_t closedTitleHash;
+	uint64_t closedTitleHash;
 	std::filesystem::path resultPath;
 
-	DialogType currentDialogType;
-	uint32_t currentTitleHash;
-	const char* currentTitle;
-	const char* currentActionText;
+	uint64_t currentTitleHash;
 
-	void CloseDialog(bool canceled);
+	Descriptor descriptor;
 };
 
 }

--- a/editor/src/main.cpp
+++ b/editor/src/main.cpp
@@ -50,8 +50,8 @@ int main(int argc, char** argv)
 		using EditorConst = kokko::editor::EditorConstants;
 
 		FilesystemVirtual::MountPoint mounts[] = {
-			FilesystemVirtual::MountPoint{ StringRef(EditorConst::VirtualPathEngine), StringRef("engine/res") },
-			FilesystemVirtual::MountPoint{ StringRef(EditorConst::VirtualPathEditor), StringRef("editor/res") }
+			FilesystemVirtual::MountPoint{ StringRef(EditorConst::VirtualMountEngine), StringRef("engine/res") },
+			FilesystemVirtual::MountPoint{ StringRef(EditorConst::VirtualMountEditor), StringRef("editor/res") }
 		};
 		filesystem.SetMountPoints(ArrayView(mounts));
 

--- a/engine/src/Core/Array.hpp
+++ b/engine/src/Core/Array.hpp
@@ -3,6 +3,7 @@
 #include <cstring>
 #include <cstddef>
 #include <new>
+#include <utility>
 
 #include "Core/Core.hpp"
 #include "Core/ArrayView.hpp"
@@ -109,29 +110,36 @@ public:
 	}
 
 	/**
-	 * Add an item to the back of the array
+	 * Add an item to the back of the array by copying
 	 */
 	void PushBack(const ValueType& value)
 	{
-		this->Reserve(this->count + 1);
+		Reserve(count + 1);
+		new (data + count) ValueType(value);
+		++count;
+	}
 
-		ValueType* ptr = new (this->data + this->count) ValueType;
-		*ptr = value;
-
-		++(this->count);
+	/**
+	 * Add an item to the back of the array by moving
+	 */
+	void PushBack(ValueType&& value)
+	{
+		Reserve(count + 1);
+		new (data + count) ValueType(std::move(value));
+		++count;
 	}
 
 	/**
 	 * Insert the specified items to the back of the array
 	 */
-	void InsertBack(const ValueType* items, size_t count)
+	void InsertBack(const ValueType* items, size_t numItems)
 	{
-		this->Reserve(this->count + count);
+		this->Reserve(count + numItems);
 
-		for (size_t i = 0; i < count; ++i)
+		for (size_t i = 0; i < numItems; ++i)
 		{
-			this->data[this->count] = items[i];
-			++(this->count);
+			new (data + count) ValueType(items[i]);
+			++count;
 		}
 	}
 

--- a/engine/src/Core/StringRef.cpp
+++ b/engine/src/Core/StringRef.cpp
@@ -235,6 +235,38 @@ TEST_CASE("StringRef can find chars")
 	CHECK(str.FindFirstNotOf("T", 10) == 10);
 }
 
+intptr_t StringRef::FindLast(const StringRef& find) const
+{
+	for (intptr_t sourceIdx = len - find.len; sourceIdx >= 0; --sourceIdx)
+	{
+		bool match = true;
+
+		for (intptr_t findIdx = 0; findIdx < find.len; ++findIdx)
+		{
+			if (str[sourceIdx + find.len - findIdx - 1] != find.str[find.len - findIdx - 1])
+			{
+				match = false;
+				break;
+			}
+		}
+
+		if (match)
+			return sourceIdx;
+	}
+
+	return -1;
+}
+
+TEST_CASE("StringRef can find last substring")
+{
+	StringRef str("Test str str");
+
+	CHECK(str.FindLast(StringRef("Test")) == 0);
+	CHECK(str.FindLast(StringRef("str")) == 9);
+	CHECK(str.FindLast(StringRef("str ")) == 5);
+	CHECK(str.FindLast(StringRef("ing")) < 0);
+}
+
 namespace kokko
 {
 uint32_t Hash32(const StringRef& value, uint32_t seed)

--- a/engine/src/Core/StringRef.hpp
+++ b/engine/src/Core/StringRef.hpp
@@ -69,6 +69,8 @@ struct StringRef
 
 	intptr_t FindFirstOf(const char* chars, size_t startAt = 0) const;
 	intptr_t FindFirstNotOf(const char* chars, size_t startAt = 0) const;
+
+	intptr_t FindLast(const StringRef& str) const;
 };
 
 namespace kokko

--- a/engine/src/Engine/Engine.cpp
+++ b/engine/src/Engine/Engine.cpp
@@ -80,7 +80,7 @@ Engine::Engine(
 
 	world.CreateScope(allocatorManager, "World", alloc);
 	world.New(allocatorManager, world.allocator, debugNameAllocator, renderDevice,
-		filesystem, assetLoader, mainWindow.instance->GetInputManager(), resManagers);
+		assetLoader, mainWindow.instance->GetInputManager(), resManagers);
 }
 
 Engine::~Engine()

--- a/engine/src/Engine/World.cpp
+++ b/engine/src/Engine/World.cpp
@@ -21,27 +21,21 @@
 #include "Rendering/LightManager.hpp"
 #include "Rendering/Renderer.hpp"
 
+#include "Resources/AssetLoader.hpp"
+
 #include "Scripting/ScriptSystem.hpp"
 
-#include "System/Filesystem.hpp"
 #include "System/Window.hpp"
-
-static const char* const UnnamedLevelDisplayName = "Unnamed level";
 
 World::World(AllocatorManager* allocManager,
 	Allocator* allocator,
 	Allocator* debugNameAllocator,
 	RenderDevice* renderDevice,
-	Filesystem* filesystem,
 	kokko::AssetLoader* assetLoader,
 	InputManager* inputManager,
 	const ResourceManagers& resourceManagers) :
 	allocator(allocator),
-	filesystem(filesystem),
-	assetLoader(assetLoader),
 	levelSerializer(allocator),
-	loadedLevelDisplayName(allocator, UnnamedLevelDisplayName),
-	loadedLevelFilePath(allocator),
 	resourceManagers(resourceManagers)
 {
 	Allocator* alloc = Memory::GetDefaultAllocator();
@@ -104,38 +98,6 @@ void World::Deinitialize()
 	renderer.instance->Deinitialize();
 }
 
-bool World::LoadFromFile(const char* path, const char* displayName)
-{
-	KOKKO_PROFILE_FUNCTION();
-
-	kokko::String sceneConfig(allocator);
-
-	if (filesystem->ReadText(path, sceneConfig))
-	{
-		levelSerializer.DeserializeFromString(sceneConfig.GetData());
-
-		loadedLevelDisplayName.Assign(displayName);
-		loadedLevelFilePath.Assign(path);
-
-		return true;
-	}
-
-	return false;
-}
-
-bool World::WriteToFile(const char* path, const char* displayName)
-{
-	if (levelSerializer.SerializeToFile(path))
-	{
-		loadedLevelDisplayName.Assign(displayName);
-		loadedLevelFilePath.Assign(path);
-
-		return true;
-	}
-	else
-		return false;
-}
-
 void World::ClearAllEntities()
 {
 	environmentSystem.instance->RemoveAll();
@@ -147,9 +109,6 @@ void World::ClearAllEntities()
 	renderer.instance->RemoveAll();
 	scene.instance->Clear();
 	entityManager.instance->ClearAll();
-
-	loadedLevelDisplayName.Assign(UnnamedLevelDisplayName);
-	loadedLevelFilePath.Clear();
 }
 
 void World::Update()

--- a/engine/src/Engine/World.hpp
+++ b/engine/src/Engine/World.hpp
@@ -45,7 +45,6 @@ public:
 		Allocator* allocator,
 		Allocator* debugNameAllocator,
 		RenderDevice* renderDevice,
-		Filesystem* filesystem,
 		kokko::AssetLoader* assetLoader,
 		InputManager* inputManager,
 		const ResourceManagers& resourceManagers);
@@ -54,16 +53,11 @@ public:
 	void Initialize();
 	void Deinitialize();
 
-	bool LoadFromFile(const char* path, const char* displayName);
-	bool WriteToFile(const char* path, const char* displayName);
-
 	void ClearAllEntities();
 
 	void Update();
 	void Render(const Optional<CameraParameters>& editorCamera, const Framebuffer& framebuffer);
 	void DebugRender(EngineSettings* engineSettings, DebugVectorRenderer* vectorRenderer);
-
-	const kokko::String& GetLoadedLevelFilename() { return loadedLevelDisplayName; }
 
 	EntityManager* GetEntityManager() { return entityManager.instance; }
 	Scene* GetScene() { return scene.instance; }
@@ -79,13 +73,8 @@ public:
 
 private:
 	Allocator* allocator;
-	Filesystem* filesystem;
-	kokko::AssetLoader* assetLoader;
 
 	LevelSerializer levelSerializer;
-
-	kokko::String loadedLevelDisplayName;
-	kokko::String loadedLevelFilePath;
 
 	InstanceAllocatorPair<EntityManager> entityManager;
 	InstanceAllocatorPair<LightManager> lightManager;

--- a/engine/src/Resources/LevelSerializer.cpp
+++ b/engine/src/Resources/LevelSerializer.cpp
@@ -1,6 +1,6 @@
 #include "Resources/LevelSerializer.hpp"
 
-#include <fstream>
+#include <sstream>
 
 #include "Engine/ComponentSerializer.hpp"
 #include "Engine/EntityManager.hpp"
@@ -66,36 +66,32 @@ void LevelSerializer::DeserializeFromString(const char* data)
 	}
 }
 
-bool LevelSerializer::SerializeToFile(const char* filePath)
+void LevelSerializer::SerializeToString(kokko::String& out)
 {
 	KOKKO_PROFILE_FUNCTION();
 
-	std::ofstream outStream(filePath);
-
-	if (outStream.is_open() == false)
-		return false;
-
-	YAML::Emitter out(outStream);
+	std::stringstream outStream;
+	YAML::Emitter emitter(outStream);
 
 	EntityManager* entityManager = world->GetEntityManager();
 	Scene* scene = world->GetScene();
-	kokko::EnvironmentSystem* envSystem = world->GetEnvironmentSystem();
 
-	out << YAML::BeginMap;
+	emitter << YAML::BeginMap;
 
-	out << YAML::Key << "objects" << YAML::Value << YAML::BeginSeq;
+	emitter << YAML::Key << "objects" << YAML::Value << YAML::BeginSeq;
 
 	for (Entity entity : *entityManager)
 	{
 		SceneObjectId sceneObj = scene->Lookup(entity);
 		if (sceneObj == SceneObjectId::Null || scene->GetParent(sceneObj) == SceneObjectId::Null)
-			WriteEntity(out, entity, sceneObj);
+			WriteEntity(emitter, entity, sceneObj);
 	}
-	out << YAML::EndSeq; // objects
+	emitter << YAML::EndSeq; // objects
 
-	out << YAML::EndMap;
+	emitter << YAML::EndMap;
 
-	return true;
+	std::string str = outStream.str();
+	out.Assign(StringRef(str.c_str(), str.length()));
 }
 
 void LevelSerializer::DeserializeEntitiesFromString(const char* data, SceneObjectId parent)

--- a/engine/src/Resources/LevelSerializer.hpp
+++ b/engine/src/Resources/LevelSerializer.hpp
@@ -34,7 +34,7 @@ public:
 	void Initialize(World* world, const ResourceManagers& resourceManagers);
 
 	void DeserializeFromString(const char* data);
-	bool SerializeToFile(const char* filePath);
+	void SerializeToString(kokko::String& out);
 
 	void DeserializeEntitiesFromString(const char* data, SceneObjectId parent);
 	void SerializeEntitiesToString(ArrayView<Entity> serializeEntities, kokko::String& serializedOut);

--- a/engine/src/System/Filesystem.hpp
+++ b/engine/src/System/Filesystem.hpp
@@ -19,5 +19,5 @@ public:
 
 	virtual bool ReadBinary(const char* path, Array<uint8_t>& output) = 0;
 	virtual bool ReadText(const char* path, kokko::String& output) = 0;
-	virtual bool WriteText(const char* path, ArrayView<const char> content, bool append) = 0;
+	virtual bool Write(const char* path, ArrayView<const uint8_t> content, bool append) = 0;
 };

--- a/engine/src/System/FilesystemDefault.cpp
+++ b/engine/src/System/FilesystemDefault.cpp
@@ -58,7 +58,7 @@ bool FilesystemDefault::ReadText(const char* path, kokko::String& output)
 	return false;
 }
 
-bool FilesystemDefault::WriteText(const char* path, ArrayView<const char> content, bool append)
+bool FilesystemDefault::Write(const char* path, ArrayView<const uint8_t> content, bool append)
 {
 	KOKKO_PROFILE_FUNCTION();
 

--- a/engine/src/System/FilesystemDefault.hpp
+++ b/engine/src/System/FilesystemDefault.hpp
@@ -7,5 +7,5 @@ class FilesystemDefault : public Filesystem
 public:
 	virtual bool ReadBinary(const char* path, Array<uint8_t>& output) override;
 	virtual bool ReadText(const char* path, kokko::String& output) override;
-	virtual bool WriteText(const char* path, ArrayView<const char> content, bool append) override;
+	virtual bool Write(const char* path, ArrayView<const uint8_t> content, bool append) override;
 };

--- a/engine/src/System/FilesystemRelative.cpp
+++ b/engine/src/System/FilesystemRelative.cpp
@@ -41,10 +41,10 @@ bool FilesystemRelative::ReadText(const char* path, kokko::String& output)
 	return result;
 }
 
-bool FilesystemRelative::WriteText(const char* path, ArrayView<const char> content, bool append)
+bool FilesystemRelative::Write(const char* path, ArrayView<const uint8_t> content, bool append)
 {
 	pathStore.Append(path);
-	bool result = defaultFs.WriteText(pathStore.GetCStr(), content, append);
+	bool result = defaultFs.Write(pathStore.GetCStr(), content, append);
 	pathStore.Resize(basePathLength);
 
 	return result;

--- a/engine/src/System/FilesystemRelative.hpp
+++ b/engine/src/System/FilesystemRelative.hpp
@@ -19,7 +19,7 @@ public:
 
 	virtual bool ReadBinary(const char* path, Array<uint8_t>& output) override;
 	virtual bool ReadText(const char* path, kokko::String& output) override;
-	virtual bool WriteText(const char* path, ArrayView<const char> content, bool append) override;
+	virtual bool Write(const char* path, ArrayView<const uint8_t> content, bool append) override;
 
 private:
 	kokko::String pathStore;

--- a/engine/src/System/FilesystemVirtual.cpp
+++ b/engine/src/System/FilesystemVirtual.cpp
@@ -105,17 +105,17 @@ bool FilesystemVirtual::ReadText(const char* path, kokko::String& output)
 	}
 }
 
-bool FilesystemVirtual::WriteText(const char* path, ArrayView<const char> content, bool append)
+bool FilesystemVirtual::Write(const char* path, ArrayView<const uint8_t> content, bool append)
 {
 	if (FindMountedPath(path))
 	{
-		bool result = defaultFs.WriteText(pathStore.GetCStr(), content, append);
+		bool result = defaultFs.Write(pathStore.GetCStr(), content, append);
 		pathStore.Clear();
 		return result;
 	}
 	else
 	{
-		return defaultFs.WriteText(path, content, append);
+		return defaultFs.Write(path, content, append);
 	}
 }
 

--- a/engine/src/System/FilesystemVirtual.hpp
+++ b/engine/src/System/FilesystemVirtual.hpp
@@ -26,7 +26,7 @@ public:
 
 	virtual bool ReadBinary(const char* path, Array<uint8_t>& output) override;
 	virtual bool ReadText(const char* path, kokko::String& output) override;
-	virtual bool WriteText(const char* path, ArrayView<const char> content, bool append) override;
+	virtual bool Write(const char* path, ArrayView<const uint8_t> content, bool append) override;
 
 private:
 	bool FindMountedPath(const char* path);


### PR DESCRIPTION
- Levels are part of asset library and are identified with UIDs
- Levels are opened from the asset browser view
- FilePickerDialog has option for using asset directory relative paths
- File handling code is removed from LevelSerializer, it now only works to serialize from and to string types.
- Level loading and saving code is removed from World
- Last opened level is opened on editor boot
- Some improvements to Array and StringRef types
- Other minor refactoring and renames