### PR TITLE
Fix glTF loading for index types other than 16-bit

### DIFF
--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -174,8 +174,8 @@ set (KOKKO_SOURCES
 	src/Graphics/TransformUpdateReceiver.hpp
 	src/Graphics/Scene.cpp
 	src/Graphics/Scene.hpp
-	src/Math/BoundingBox.cpp
-	src/Math/BoundingBox.hpp
+	src/Math/AABB.cpp
+	src/Math/AABB.hpp
 	src/Math/Frustum.hpp
 	src/Math/Intersect3D.cpp
 	src/Math/Intersect3D.hpp

--- a/engine/src/Debug/DebugTextRenderer.cpp
+++ b/engine/src/Debug/DebugTextRenderer.cpp
@@ -326,11 +326,9 @@ void DebugTextRenderer::CreateAndUploadData()
 	data.vertexData = vertexData.GetData();
 	data.vertexDataSize = vertexData.GetCount() * sizeof(vertexData[0]);
 	data.vertexCount = vertexData.GetCount() / static_cast<int>(componentCount);
-	data.vertexBufferUsage = RenderBufferUsage::DynamicDraw;
 	data.indexData = indexData.GetData();
 	data.indexDataSize = indexData.GetCount() * sizeof(indexData[0]);
-	data.indexCount = static_cast<unsigned int>(indexData.GetCount());
-	data.indexBufferUsage = RenderBufferUsage::DynamicDraw;
+	data.indexCount = static_cast<uint32_t>(indexData.GetCount());
 
 	meshManager->UploadIndexed(meshId, data);
 

--- a/engine/src/Debug/DebugVectorRenderer.cpp
+++ b/engine/src/Debug/DebugVectorRenderer.cpp
@@ -348,7 +348,6 @@ void DebugVectorRenderer::DrawLineChainScreen(size_t count, const Vec3f* points,
 		VertexData data;
 		data.vertexFormat = vertexFormatPos;
 		data.primitiveMode = RenderPrimitiveMode::LineStrip;
-		data.vertexBufferUsage = RenderBufferUsage::DynamicDraw;
 		data.vertexData = reinterpret_cast<const float*>(points);
 		data.vertexDataSize = static_cast<unsigned int>(requiredBufferSize);
 		data.vertexCount = static_cast<unsigned int>(count);

--- a/engine/src/Graphics/TerrainQuadTree.cpp
+++ b/engine/src/Graphics/TerrainQuadTree.cpp
@@ -10,7 +10,7 @@
 
 #include "Graphics/TerrainSystem.hpp"
 
-#include "Math/BoundingBox.hpp"
+#include "Math/AABB.hpp"
 #include "Math/Frustum.hpp"
 #include "Math/Intersect3D.hpp"
 
@@ -121,7 +121,7 @@ void TerrainQuadTree::RenderTile(
 	Vec3f tileMin = levelOrigin + Vec3f(id.x * tileWidth, terrainBottom, id.y * tileWidth);
 	Vec3f tileSize(tileWidth, terrainHeight, tileWidth);
 
-	BoundingBox tileBounds;
+	AABB tileBounds;
 	tileBounds.extents = tileSize * 0.5f;
 	tileBounds.center = tileMin + tileBounds.extents;
 

--- a/engine/src/Math/AABB.cpp
+++ b/engine/src/Math/AABB.cpp
@@ -1,17 +1,20 @@
-#include "Math/BoundingBox.hpp"
+#include "Math/AABB.hpp"
 
 #include <cmath>
 #include <algorithm>
 #include <limits>
 
-BoundingBox BoundingBox::Transform(const Mat4x4f& m) const
+namespace kokko
+{
+
+AABB AABB::Transform(const Mat4x4f& m) const
 {
 	Mat4x4f absm;
 
 	for (int i = 0; i < 16; ++i)
 		absm[i] = std::abs(m[i]);
 
-	BoundingBox result;
+	AABB result;
 
 	result.center = (m * Vec4f(this->center, 1.0f)).xyz();
 	result.extents = (absm * Vec4f(this->extents, 0.0f)).xyz();
@@ -19,7 +22,7 @@ BoundingBox BoundingBox::Transform(const Mat4x4f& m) const
 	return result;
 }
 
-void BoundingBox::UpdateToContain(unsigned int count, const Vec3f* points)
+void AABB::UpdateToContain(unsigned int count, const Vec3f* points)
 {
 	constexpr float fmax = std::numeric_limits<float>::max();
 	constexpr float fmin = std::numeric_limits<float>::min();
@@ -42,3 +45,5 @@ void BoundingBox::UpdateToContain(unsigned int count, const Vec3f* points)
 	extents = difference * 0.5f;
 	center = minimum + extents;
 }
+
+} // namespace kokko

--- a/engine/src/Math/AABB.hpp
+++ b/engine/src/Math/AABB.hpp
@@ -3,11 +3,16 @@
 #include "Math/Vec3.hpp"
 #include "Math/Mat4x4.hpp"
 
-struct BoundingBox
+namespace kokko
+{
+
+struct AABB
 {
 	Vec3f center;
 	Vec3f extents;
 
-	BoundingBox Transform(const Mat4x4f& m) const;
+	AABB Transform(const Mat4x4f& m) const;
 	void UpdateToContain(unsigned int count, const Vec3f* points);
 };
+
+} // namespace kokko

--- a/engine/src/Math/Intersect3D.cpp
+++ b/engine/src/Math/Intersect3D.cpp
@@ -5,12 +5,12 @@
 #include "Core/Core.hpp"
 #include "Core/BitPack.hpp"
 
-#include "Math/BoundingBox.hpp"
+#include "Math/AABB.hpp"
 #include "Math/Frustum.hpp"
 #include "Math/Mat4x4.hpp"
 #include "Math/Vec2.hpp"
 
-bool Intersect::FrustumAabb(const FrustumPlanes& frustum, const BoundingBox& bounds)
+bool Intersect::FrustumAabb(const FrustumPlanes& frustum, const kokko::AABB& bounds)
 {
 	KOKKO_PROFILE_FUNCTION();
 
@@ -37,7 +37,7 @@ bool Intersect::FrustumAabb(const FrustumPlanes& frustum, const BoundingBox& bou
 void Intersect::FrustumAabbN(
 	const FrustumPlanes& frustum,
 	unsigned int count,
-	const BoundingBox* bounds,
+	const kokko::AABB* bounds,
 	BitPack* intersectedOut)
 {
 	KOKKO_PROFILE_FUNCTION();
@@ -79,7 +79,7 @@ void Intersect::FrustumAABBMinSize(
 	const Mat4x4f& viewProjection,
 	float minimumSize,
 	unsigned int count,
-	const BoundingBox* bounds,
+	const kokko::AABB* bounds,
 	BitPack* intersectedOut)
 {
 	KOKKO_PROFILE_FUNCTION();

--- a/engine/src/Math/Intersect3D.hpp
+++ b/engine/src/Math/Intersect3D.hpp
@@ -2,10 +2,14 @@
 
 #include "Math/Vec3.hpp"
 
-struct BoundingBox;
 struct Mat4x4f;
 struct FrustumPlanes;
 struct BitPack;
+
+namespace kokko
+{
+struct AABB;
+}
 
 namespace Intersect
 {
@@ -14,7 +18,7 @@ namespace Intersect
 	*/
 	bool FrustumAabb(
 	const FrustumPlanes& frustum,
-	const BoundingBox& bounds);
+	const kokko::AABB& bounds);
 
 	/*
 	* Calculate visibility for bounding boxes
@@ -22,7 +26,7 @@ namespace Intersect
 	void FrustumAabbN(
 		const FrustumPlanes& frustum,
 		unsigned int count,
-		const BoundingBox* bounds,
+		const kokko::AABB* bounds,
 		BitPack* intersectedOut);
 
 	/*
@@ -33,7 +37,7 @@ namespace Intersect
 		const Mat4x4f& viewProjection,
 		float minimumSize,
 		unsigned int count,
-		const BoundingBox* bounds,
+		const kokko::AABB* bounds,
 		BitPack* intersectedOut);
 
 	/*

--- a/engine/src/Rendering/CascadedShadowMap.cpp
+++ b/engine/src/Rendering/CascadedShadowMap.cpp
@@ -6,7 +6,6 @@
 #include "Math/Vec2.hpp"
 #include "Math/Math.hpp"
 #include "Math/Frustum.hpp"
-#include "Math/BoundingBox.hpp"
 
 namespace CascadedShadowMap
 {

--- a/engine/src/Rendering/MeshComponentSystem.cpp
+++ b/engine/src/Rendering/MeshComponentSystem.cpp
@@ -4,7 +4,7 @@
 
 #include "Engine/Entity.hpp"
 
-#include "Math/BoundingBox.hpp"
+#include "Math/AABB.hpp"
 #include "Math/Mat4x4.hpp"
 
 #include "Resources/MaterialData.hpp"
@@ -47,7 +47,7 @@ void MeshComponentSystem::NotifyUpdatedTransforms(size_t count, const Entity* en
 
 			if (meshId != MeshId::Null)
 			{
-				const BoundingBox* bounds = meshManager->GetBoundingBox(meshId);
+				const AABB* bounds = meshManager->GetBoundingBox(meshId);
 				data.bounds[dataIdx] = bounds->Transform(transforms[entityIdx]);
 			}
 
@@ -88,7 +88,7 @@ void MeshComponentSystem::AddComponents(unsigned int count, const Entity* entiti
 		data.mesh[id] = MeshId::Null;
 		data.material[id] = MaterialId::Null;
 		data.transparency[id] = TransparencyType::Opaque;
-		data.bounds[id] = BoundingBox();
+		data.bounds[id] = AABB();
 		data.transform[id] = Mat4x4f();
 
 		idsOut[i].i = id;
@@ -172,7 +172,7 @@ void MeshComponentSystem::Reallocate(unsigned int required)
 
 	InstanceData newData;
 	unsigned int bytes = required * (sizeof(Entity) + sizeof(MeshId) + sizeof(MaterialId) +
-		sizeof(TransparencyType) + sizeof(BoundingBox) + sizeof(Mat4x4f));
+		sizeof(TransparencyType) + sizeof(AABB) + sizeof(Mat4x4f));
 
 	newData.buffer = this->allocator->Allocate(bytes, "MeshComponentSystem.data.buffer");
 	newData.count = data.count;
@@ -182,7 +182,7 @@ void MeshComponentSystem::Reallocate(unsigned int required)
 	newData.mesh = reinterpret_cast<MeshId*>(newData.entity + required);
 	newData.material = reinterpret_cast<MaterialId*>(newData.mesh + required);
 	newData.transparency = reinterpret_cast<TransparencyType*>(newData.material + required);
-	newData.bounds = reinterpret_cast<BoundingBox*>(newData.transparency + required);
+	newData.bounds = reinterpret_cast<AABB*>(newData.transparency + required);
 	newData.transform = reinterpret_cast<Mat4x4f*>(newData.bounds + required);
 
 	if (data.buffer != nullptr)
@@ -191,7 +191,7 @@ void MeshComponentSystem::Reallocate(unsigned int required)
 		std::memcpy(newData.mesh, data.mesh, data.count * sizeof(MeshId));
 		std::memcpy(newData.material, data.material, data.count * sizeof(MaterialId));
 		std::memcpy(newData.transparency, data.transparency, data.count * sizeof(TransparencyType));
-		std::memcpy(newData.bounds, data.bounds, data.count * sizeof(BoundingBox));
+		std::memcpy(newData.bounds, data.bounds, data.count * sizeof(AABB));
 		std::memcpy(newData.transform, data.transform, data.count * sizeof(Mat4x4f));
 
 		this->allocator->Deallocate(data.buffer);

--- a/engine/src/Rendering/MeshComponentSystem.hpp
+++ b/engine/src/Rendering/MeshComponentSystem.hpp
@@ -8,7 +8,6 @@
 
 class Allocator;
 
-struct BoundingBox;
 struct Entity;
 struct Mat4x4f;
 
@@ -17,6 +16,8 @@ namespace kokko
 
 class MeshManager;
 class Renderer;
+
+struct AABB;
 struct MaterialId;
 struct MeshId;
 
@@ -71,7 +72,7 @@ private:
 		MeshId* mesh;
 		MaterialId* material;
 		TransparencyType* transparency;
-		BoundingBox* bounds;
+		AABB* bounds;
 		Mat4x4f* transform;
 	}
 	data;

--- a/engine/src/Rendering/Renderer.cpp
+++ b/engine/src/Rendering/Renderer.cpp
@@ -24,8 +24,8 @@
 #include "Graphics/GraphicsFeatureTonemapping.hpp"
 #include "Graphics/Scene.hpp"
 
+#include "Math/AABB.hpp"
 #include "Math/Rectangle.hpp"
-#include "Math/BoundingBox.hpp"
 #include "Math/Intersect3D.hpp"
 
 #include "Memory/Allocator.hpp"
@@ -1004,7 +1004,7 @@ void Renderer::DebugRender(DebugVectorRenderer* vectorRenderer)
 		Color color(1.0f, 1.0f, 1.0f, 1.0f);
 
 		// Draw bounds
-		BoundingBox* bounds = componentSystem->data.bounds;
+		AABB* bounds = componentSystem->data.bounds;
 		for (unsigned int idx = 1, count = componentSystem->data.count; idx < count; ++idx)
 		{
 			Vec3f pos = bounds[idx].center;

--- a/engine/src/Resources/AssetLibrary.cpp
+++ b/engine/src/Resources/AssetLibrary.cpp
@@ -576,15 +576,15 @@ void AssetInfo::UpdateFilename(ConstStringView newFilename)
 TEST_CASE("AssetInfo.VirtualPathParts")
 {
 	Uid uid;
-	uid.raw[0] = 877228993468580528;
-	uid.raw[1] = 6433944024937364386;
+	uid.raw[0] = 877228993468580528ull;
+	uid.raw[1] = 6433944024937364386ull;
 
 	AssetInfo assetInfo(
 		Allocator::GetDefault(),
 		ConstStringView("engine"),
 		ConstStringView("materials/deferred_geometry/fallback.material"),
 		uid,
-		12570451739923486631,
+		12570451739923486631ull,
 		AssetType::Material);
 
 	CHECK(assetInfo.GetVirtualPath() == ConstStringView("engine/materials/deferred_geometry/fallback.material"));

--- a/engine/src/Resources/MeshManager.cpp
+++ b/engine/src/Resources/MeshManager.cpp
@@ -51,7 +51,7 @@ void MeshManager::Reallocate(unsigned int required)
 	required = static_cast<unsigned int>(Math::UpperPowerOfTwo(required));
 
 	size_t objectBytes = sizeof(unsigned int) * 2 + sizeof(MeshDrawData) + sizeof(int) +
-		sizeof(MeshBufferData) + sizeof(BoundingBox) + sizeof(MeshId) + sizeof(kokko::Uid) + sizeof(bool);
+		sizeof(MeshBufferData) + sizeof(AABB) + sizeof(MeshId) + sizeof(kokko::Uid) + sizeof(bool);
 
 	InstanceData newData;
 	newData.buffer = allocator->Allocate(required * objectBytes, "MeshManager.data.buffer");
@@ -63,7 +63,7 @@ void MeshManager::Reallocate(unsigned int required)
 	newData.drawData = reinterpret_cast<MeshDrawData*>(newData.indexList + newData.allocated);
 	newData.bufferData = reinterpret_cast<MeshBufferData*>(newData.drawData + newData.allocated);
 	newData.uniqueVertexCount = reinterpret_cast<int*>(newData.bufferData + newData.allocated);
-	newData.bounds = reinterpret_cast<BoundingBox*>(newData.bufferData + newData.allocated);
+	newData.bounds = reinterpret_cast<AABB*>(newData.bufferData + newData.allocated);
 	newData.meshId = reinterpret_cast<MeshId*>(newData.bounds + newData.allocated);
 	newData.uid = reinterpret_cast<kokko::Uid*>(newData.meshId + newData.allocated);
 	newData.uidExists = reinterpret_cast<bool*>(newData.uid + newData.allocated);
@@ -81,7 +81,7 @@ void MeshManager::Reallocate(unsigned int required)
 		std::memcpy(newData.drawData, data.drawData, data.count * sizeof(MeshDrawData));
 		std::memcpy(newData.bufferData, data.bufferData, data.count * sizeof(MeshBufferData));
 		std::memcpy(newData.uniqueVertexCount, data.uniqueVertexCount, data.count * sizeof(int));
-		std::memcpy(newData.bounds, data.bounds, data.count * sizeof(BoundingBox));
+		std::memcpy(newData.bounds, data.bounds, data.count * sizeof(AABB));
 		std::memcpy(newData.meshId, data.meshId, data.count * sizeof(MeshId));
 		std::memcpy(newData.uid, data.uid, data.count * sizeof(kokko::Uid));
 		std::memcpy(newData.uidExists, data.uidExists, data.count * sizeof(bool));
@@ -116,7 +116,7 @@ MeshId MeshManager::CreateMesh()
 	data.drawData[index] = MeshDrawData{};
 	data.bufferData[index] = MeshBufferData{};
 	data.uniqueVertexCount[index] = 0;
-	data.bounds[index] = BoundingBox();
+	data.bounds[index] = AABB();
 	data.meshId[index] = id;
 	data.uid[index] = kokko::Uid();
 	data.uidExists[index] = false;
@@ -184,12 +184,12 @@ void MeshManager::SetUid(MeshId id, const kokko::Uid& uid)
 	data.uidExists[index] = true;
 }
 
-const BoundingBox* MeshManager::GetBoundingBox(MeshId id) const
+const AABB* MeshManager::GetBoundingBox(MeshId id) const
 {
 	return &data.bounds[GetIndex(id)];
 }
 
-void MeshManager::SetBoundingBox(MeshId id, const BoundingBox& bounds)
+void MeshManager::SetBoundingBox(MeshId id, const AABB& bounds)
 {
 	data.bounds[GetIndex(id)] = bounds;
 }

--- a/engine/src/Resources/MeshManager.cpp
+++ b/engine/src/Resources/MeshManager.cpp
@@ -348,7 +348,7 @@ void MeshManager::CreateDrawDataIndexed(unsigned int index, const IndexedVertexD
 	drawData.primitiveMode = vdata.primitiveMode;
 	drawData.vertexArrayObject = data.bufferData[index].vertexArrayObject;
 	drawData.count = static_cast<int>(vdata.indexCount);
-	drawData.indexType = RenderIndexType::UnsignedShort;
+	drawData.indexType = vdata.indexType;
 
 	data.uniqueVertexCount[index] = static_cast<int>(vdata.vertexCount);
 }

--- a/engine/src/Resources/MeshManager.hpp
+++ b/engine/src/Resources/MeshManager.hpp
@@ -7,15 +7,13 @@
 #include "Core/StringView.hpp"
 #include "Core/Uid.hpp"
 
-#include "Math/BoundingBox.hpp"
+#include "Math/AABB.hpp"
 
 #include "Rendering/RenderTypes.hpp"
 #include "Rendering/RenderResourceId.hpp"
 #include "Rendering/VertexFormat.hpp"
 
 #include "Resources/MeshId.hpp"
-
-struct BoundingBox;
 
 class Allocator;
 
@@ -112,15 +110,15 @@ private:
 		MeshDrawData* drawData;
 		MeshBufferData* bufferData;
 		int* uniqueVertexCount; // Used for rendering normal visualization
-		BoundingBox* bounds;
+		AABB* bounds;
 		MeshId* meshId;
-		kokko::Uid* uid;
+		Uid* uid;
 		bool* uidExists;
 	}
 	data;
 
 	unsigned int freeListFirst;
-	HashMap<kokko::Uid, MeshId> uidMap;
+	HashMap<Uid, MeshId> uidMap;
 
 	void Reallocate(unsigned int required);
 
@@ -137,17 +135,17 @@ private:
 	unsigned int GetIndex(MeshId meshId) const;
 
 public:
-	MeshManager(Allocator* allocator, kokko::AssetLoader* assetLoader, kokko::render::Device* renderDevice);
+	MeshManager(Allocator* allocator, AssetLoader* assetLoader, render::Device* renderDevice);
 	~MeshManager();
 
 	MeshId CreateMesh();
 	void RemoveMesh(MeshId id);
 
-	Optional<kokko::Uid> GetUid(MeshId id) const;
-	void SetUid(MeshId id, const kokko::Uid& uid);
+	Optional<Uid> GetUid(MeshId id) const;
+	void SetUid(MeshId id, const Uid& uid);
 
-	const BoundingBox* GetBoundingBox(MeshId id) const;
-	void SetBoundingBox(MeshId id, const BoundingBox& bounds);
+	const AABB* GetBoundingBox(MeshId id) const;
+	void SetBoundingBox(MeshId id, const AABB& bounds);
 
 	const MeshDrawData* GetDrawData(MeshId id) const;
 	int GetUniqueVertexCount(MeshId id) const;

--- a/engine/src/Resources/MeshManager.hpp
+++ b/engine/src/Resources/MeshManager.hpp
@@ -32,7 +32,6 @@ class Device;
 struct VertexData
 {
 	VertexData() :
-		vertexBufferUsage(RenderBufferUsage::StaticDraw),
 		primitiveMode(RenderPrimitiveMode::Triangles),
 		vertexData(nullptr),
 		vertexDataSize(0),
@@ -41,32 +40,28 @@ struct VertexData
 	}
 
 	VertexFormat vertexFormat;
-	RenderBufferUsage vertexBufferUsage;
 
 	RenderPrimitiveMode primitiveMode;
 
 	const void* vertexData;
-	unsigned int vertexDataSize;
-
-	unsigned int vertexCount;
+	size_t vertexDataSize;
+	uint32_t vertexCount;
 };
 
 struct IndexedVertexData : VertexData
 {
 	IndexedVertexData() :
-		indexBufferUsage(RenderBufferUsage::StaticDraw),
 		indexData(nullptr),
 		indexDataSize(0),
-		indexCount(0)
+		indexCount(0),
+		indexType(RenderIndexType::UnsignedShort)
 	{
 	}
 
-	RenderBufferUsage indexBufferUsage;
-
 	const void* indexData;
-	unsigned int indexDataSize;
-
-	unsigned int indexCount;
+	size_t indexDataSize;
+	uint32_t indexCount;
+	RenderIndexType indexType;
 };
 
 struct MeshDrawData

--- a/engine/src/Resources/MeshPresets.cpp
+++ b/engine/src/Resources/MeshPresets.cpp
@@ -46,7 +46,7 @@ void MeshPresets::UploadCube(MeshManager* meshManager, MeshId meshId)
 
 	meshManager->UploadIndexed(meshId, data);
 
-	BoundingBox bounds;
+	AABB bounds;
 	bounds.center = Vec3f(0.0f, 0.0f, 0.0f);
 	bounds.extents = Vec3f(0.5f, 0.5f, 0.5f);
 	meshManager->SetBoundingBox(meshId, bounds);

--- a/engine/src/Resources/ModelLoader.cpp
+++ b/engine/src/Resources/ModelLoader.cpp
@@ -203,7 +203,7 @@ bool ModelLoader::LoadMesh(cgltf_mesh* cgltfMesh, ModelMesh& modelMeshOut)
 	size_t vertexBufferStartOffset = 0;
 	size_t vertexBufferEndOffset = 0;
 
-	BoundingBox meshBounds;
+	AABB meshBounds;
 
 	for (size_t i = 0; i < prim.attributes_count; ++i)
 	{

--- a/engine/src/Resources/ModelManager.cpp
+++ b/engine/src/Resources/ModelManager.cpp
@@ -63,6 +63,11 @@ ModelId ModelManager::FindModelByUid(const kokko::Uid& uid)
 		}
 		else
 		{
+			char uidStr[Uid::StringLength + 1];
+			uid.WriteTo(uidStr);
+			uidStr[Uid::StringLength] = '\0';
+
+			KK_LOG_ERROR("Model with UID {} failed to be loaded.", uidStr);
 			models.PopBack();
 		}
 	}

--- a/engine/src/Resources/ModelManager.hpp
+++ b/engine/src/Resources/ModelManager.hpp
@@ -71,15 +71,15 @@ private:
 
 	struct ModelData
 	{
-		void* buffer;
+		void* buffer = nullptr;
 
 		kokko::Uid uid;
 
-		ModelNode* nodes;
-		uint32_t nodeCount;
+		ModelNode* nodes = nullptr;
+		uint32_t nodeCount = 0;
 
-		uint32_t meshCount;
-		ModelMesh* meshes;
+		uint32_t meshCount = 0;
+		ModelMesh* meshes = nullptr;
 	};
 
 	Allocator* allocator;


### PR DESCRIPTION
Fixes an issue where some glTF files failed to load correctly if their meshes used 8-bit or 32-bit index types. Usually model loader failed to identify the problem during loading, but the loaded model had significant problems.