### PR TITLE
Rename mesh primitive to mesh part

### DIFF
--- a/engine/src/Debug/DebugTextRenderer.cpp
+++ b/engine/src/Debug/DebugTextRenderer.cpp
@@ -192,10 +192,10 @@ void DebugTextRenderer::Render(kokko::render::CommandEncoder* encoder)
 		// Draw
 
 		auto& mesh = modelManager->GetModelMeshes(meshId)[0];
-		auto& prim = modelManager->GetModelPrimitives(meshId)[0];
+		auto& part = modelManager->GetModelMeshParts(meshId)[0];
 		
-		encoder->BindVertexArray(prim.vertexArrayId);
-		encoder->DrawIndexed(mesh.primitiveMode, mesh.indexType, prim.count, prim.indexOffset, 0);
+		encoder->BindVertexArray(part.vertexArrayId);
+		encoder->DrawIndexed(mesh.primitiveMode, mesh.indexType, part.count, part.indexOffset, 0);
 
 		// Clear data
 

--- a/engine/src/Debug/DebugVectorRenderer.cpp
+++ b/engine/src/Debug/DebugVectorRenderer.cpp
@@ -447,13 +447,13 @@ void DebugVectorRenderer::Render(kokko::render::CommandEncoder* encoder, World* 
 
 				ModelId meshId = staticMeshes[static_cast<unsigned int>(primitive.type)];
 				auto& mesh = modelManager->GetModelMeshes(meshId)[0];
-				auto& prim = modelManager->GetModelPrimitives(meshId)[0];
-				encoder->BindVertexArray(prim.vertexArrayId);
+				auto& part = modelManager->GetModelMeshParts(meshId)[0];
+				encoder->BindVertexArray(part.vertexArrayId);
 
 				if (mesh.indexType != RenderIndexType::None)
-					encoder->DrawIndexed(mesh.primitiveMode, mesh.indexType, prim.count, prim.indexOffset, 0);
+					encoder->DrawIndexed(mesh.primitiveMode, mesh.indexType, part.count, part.indexOffset, 0);
 				else
-					encoder->Draw(mesh.primitiveMode, 0, prim.count);
+					encoder->Draw(mesh.primitiveMode, 0, part.count);
 			}
 		}
 

--- a/engine/src/Graphics/EnvironmentSystem.cpp
+++ b/engine/src/Graphics/EnvironmentSystem.cpp
@@ -393,14 +393,14 @@ void EnvironmentSystem::Upload(render::CommandEncoder* encoder)
 			encoder->BindSampler(0, samplerId);
 
 			auto& mesh = modelManager->GetModelMeshes(cubeMeshId)[0];
-			auto& prim = modelManager->GetModelPrimitives(cubeMeshId)[0];
+			auto& part = modelManager->GetModelMeshParts(cubeMeshId)[0];
 
 			// Load shader
 
 			ShaderId equirectShaderId = shaderManager->FindShaderByPath(ConstStringView("engine/shaders/preprocess/equirect_to_cube.glsl"));
 			const ShaderData& equirectShader = shaderManager->GetShaderData(equirectShaderId);
 
-			encoder->BindVertexArray(prim.vertexArrayId);
+			encoder->BindVertexArray(part.vertexArrayId);
 			encoder->UseShaderProgram(equirectShader.driverId);
 
 			BindTexture(encoder, equirectShader, "equirectangular_map"_hash, equirectTextureId);
@@ -424,7 +424,7 @@ void EnvironmentSystem::Upload(render::CommandEncoder* encoder)
 					BindBufferRange(encoder, UniformBlockBinding::Viewport,
 						viewportUniformBufferId, viewportBlockStride * i, sizeof(ViewportUniformBlock));
 
-					encoder->DrawIndexed(mesh.primitiveMode, mesh.indexType, prim.count, prim.indexOffset, 0);
+					encoder->DrawIndexed(mesh.primitiveMode, mesh.indexType, part.count, part.indexOffset, 0);
 				}
 			}
 
@@ -467,7 +467,7 @@ void EnvironmentSystem::Upload(render::CommandEncoder* encoder)
 					BindBufferRange(encoder, UniformBlockBinding::Viewport,
 						viewportUniformBufferId, viewportBlockStride * i, sizeof(ViewportUniformBlock));
 
-					encoder->DrawIndexed(mesh.primitiveMode, mesh.indexType, prim.count, prim.indexOffset, 0);
+					encoder->DrawIndexed(mesh.primitiveMode, mesh.indexType, part.count, part.indexOffset, 0);
 				}
 			}
 
@@ -515,7 +515,7 @@ void EnvironmentSystem::Upload(render::CommandEncoder* encoder)
 						BindBufferRange(encoder, UniformBlockBinding::Viewport,
 							viewportUniformBufferId, viewportBlockStride * i, sizeof(ViewportUniformBlock));
 
-						encoder->DrawIndexed(mesh.primitiveMode, mesh.indexType, prim.count, prim.indexOffset, 0);
+						encoder->DrawIndexed(mesh.primitiveMode, mesh.indexType, part.count, part.indexOffset, 0);
 					}
 				}
 			}

--- a/engine/src/Graphics/GraphicsFeatureDeferredLighting.cpp
+++ b/engine/src/Graphics/GraphicsFeatureDeferredLighting.cpp
@@ -374,9 +374,9 @@ void GraphicsFeatureDeferredLighting::Render(const RenderParameters& parameters)
 		encoder->UseShaderProgram(calcBrdfShader.driverId);
 
 		auto& mesh = parameters.modelManager->GetModelMeshes(meshId)[0];
-		auto& prim = parameters.modelManager->GetModelPrimitives(meshId)[0];
-		encoder->BindVertexArray(prim.vertexArrayId);
-		encoder->DrawIndexed(mesh.primitiveMode, mesh.indexType, prim.count, prim.indexOffset, 0);
+		auto& part = parameters.modelManager->GetModelMeshParts(meshId)[0];
+		encoder->BindVertexArray(part.vertexArrayId);
+		encoder->DrawIndexed(mesh.primitiveMode, mesh.indexType, part.count, part.indexOffset, 0);
 
 		return;
 	}

--- a/engine/src/Graphics/GraphicsFeatureSkybox.cpp
+++ b/engine/src/Graphics/GraphicsFeatureSkybox.cpp
@@ -111,9 +111,9 @@ void GraphicsFeatureSkybox::Render(const RenderParameters& parameters)
 	encoder->BindBufferBase(RenderBufferTarget::UniformBuffer, UniformBlockBinding::Object, uniformBufferId);
 
 	auto& mesh = parameters.modelManager->GetModelMeshes(meshId)[0];
-	auto& prim = parameters.modelManager->GetModelPrimitives(meshId)[0];
-	encoder->BindVertexArray(prim.vertexArrayId);
-	encoder->DrawIndexed(mesh.primitiveMode, mesh.indexType, prim.count, prim.indexOffset, 0);
+	auto& part = parameters.modelManager->GetModelMeshParts(meshId)[0];
+	encoder->BindVertexArray(part.vertexArrayId);
+	encoder->DrawIndexed(mesh.primitiveMode, mesh.indexType, part.count, part.indexOffset, 0);
 }
 
 }

--- a/engine/src/Graphics/ParticleSystem.cpp
+++ b/engine/src/Graphics/ParticleSystem.cpp
@@ -268,8 +268,8 @@ void ParticleSystem::Render(const RenderParameters& parameters)
 	encoder->UseShaderProgram(renderShader.driverId);
 
 	auto& mesh = modelManager->GetModelMeshes(quadMeshId)[0];
-	auto& prim = modelManager->GetModelPrimitives(quadMeshId)[0];
-	encoder->BindVertexArray(prim.vertexArrayId);
+	auto& part = modelManager->GetModelMeshParts(quadMeshId)[0];
+	encoder->BindVertexArray(part.vertexArrayId);
 	encoder->DrawIndirect(mesh.primitiveMode, IndirectOffsetRender);
 
 	// Swap alive lists

--- a/engine/src/Rendering/PostProcessRenderer.cpp
+++ b/engine/src/Rendering/PostProcessRenderer.cpp
@@ -57,8 +57,8 @@ void PostProcessRenderer::RenderPasses(unsigned int count, const PostProcessRend
 	KOKKO_PROFILE_FUNCTION();
 
 	auto& mesh = modelManager->GetModelMeshes(fullscreenMeshId)[0];
-	auto& prim = modelManager->GetModelPrimitives(fullscreenMeshId)[0];
-	encoder->BindVertexArray(prim.vertexArrayId);
+	auto& part = modelManager->GetModelMeshParts(fullscreenMeshId)[0];
+	encoder->BindVertexArray(part.vertexArrayId);
 
 	for (unsigned int i = 0; i < count; ++i)
 	{
@@ -91,7 +91,7 @@ void PostProcessRenderer::RenderPasses(unsigned int count, const PostProcessRend
 		if (pass.textureCount > 0)
 			BindTextures(shader, pass.textureCount, pass.textureNameHashes, pass.textureIds, pass.samplerIds);
 
-		encoder->DrawIndexed(mesh.primitiveMode, mesh.indexType, prim.count, prim.indexOffset, 0);
+		encoder->DrawIndexed(mesh.primitiveMode, mesh.indexType, part.count, part.indexOffset, 0);
 	}
 }
 

--- a/engine/src/Rendering/Renderer.cpp
+++ b/engine/src/Rendering/Renderer.cpp
@@ -412,12 +412,12 @@ void Renderer::Render(Window* window, const Optional<CameraParameters>& editorCa
 
 				MeshId meshId = componentSystem->data.mesh[objIdx];
 				auto& mesh = modelManager->GetModelMeshes(meshId.modelId)[meshId.meshIndex];
-				auto primitives = modelManager->GetModelPrimitives(meshId.modelId);
-				for (uint16_t primIdx = mesh.primitiveOffset, end = mesh.primitiveOffset + mesh.primitiveCount; primIdx != end; ++primIdx)
+				auto parts = modelManager->GetModelMeshParts(meshId.modelId);
+				for (uint16_t partIdx = mesh.partOffset, end = mesh.partOffset + mesh.partCount; partIdx != end; ++partIdx)
 				{
-					auto& prim = primitives[primIdx];
-					encoder->BindVertexArray(prim.vertexArrayId);
-					encoder->DrawIndexed(mesh.primitiveMode, mesh.indexType, prim.count, prim.indexOffset, 0);
+					auto& part = parts[partIdx];
+					encoder->BindVertexArray(part.vertexArrayId);
+					encoder->DrawIndexed(mesh.primitiveMode, mesh.indexType, part.count, part.indexOffset, 0);
 				}
 
 				objectDrawsProcessed += 1;
@@ -986,12 +986,12 @@ void Renderer::DebugRender(DebugVectorRenderer* vectorRenderer)
 			if (meshId != MeshId::Null)
 			{
 				auto& mesh = modelManager->GetModelMeshes(meshId.modelId)[meshId.meshIndex];
-				auto primitives = modelManager->GetModelPrimitives(meshId.modelId);
-				for (uint16_t idx = mesh.primitiveOffset, end = mesh.primitiveOffset + mesh.primitiveCount; idx != end; ++idx)
+				auto parts = modelManager->GetModelMeshParts(meshId.modelId);
+				for (uint16_t idx = mesh.partOffset, end = mesh.partOffset + mesh.partCount; idx != end; ++idx)
 				{
-					auto& prim = primitives[idx];
-					int meshVertexCount = prim.uniqueVertexCount;
-					encoder->BindVertexArray(prim.vertexArrayId);
+					auto& part = parts[idx];
+					int meshVertexCount = part.uniqueVertexCount;
+					encoder->BindVertexArray(part.vertexArrayId);
 
 					// Geometry shader will turn points into lines
 					encoder->Draw(RenderPrimitiveMode::Points, 0, meshVertexCount);

--- a/engine/src/Resources/ModelManager.cpp
+++ b/engine/src/Resources/ModelManager.cpp
@@ -141,11 +141,11 @@ ArrayView<const ModelNode> ModelManager::GetModelNodes(ModelId id) const
 	return ArrayView<const ModelNode>(model.nodes, model.nodeCount);
 }
 
-ArrayView<const ModelPrimitive> ModelManager::GetModelPrimitives(ModelId id) const
+ArrayView<const ModelMeshPart> ModelManager::GetModelMeshParts(ModelId id) const
 {
 	assert(id != ModelId::Null);
 	const ModelData& model = models[id.i];
-	return ArrayView<const ModelPrimitive>(model.primitives, model.primitiveCount);
+	return ArrayView<const ModelMeshPart>(model.meshParts, model.meshPartCount);
 }
 
 void ModelManager::CreateRenderData(ModelData& model, Array<uint8_t>& geometryBuffer)
@@ -161,17 +161,17 @@ void ModelManager::CreateRenderData(ModelData& model, Array<uint8_t>& geometryBu
 	{
 		ModelMesh& mesh = model.meshes[meshIdx];
 
-		uint16_t primIdx = mesh.primitiveOffset, primEnd = mesh.primitiveOffset + mesh.primitiveCount;
+		uint16_t primIdx = mesh.partOffset, primEnd = mesh.partOffset + mesh.partCount;
 		for (; primIdx != primEnd; ++primIdx)
 		{
-			ModelPrimitive& primitive = model.primitives[primIdx];
-			VertexFormat& vertexFormat = primitive.vertexFormat;
+			ModelMeshPart& part = model.meshParts[primIdx];
+			VertexFormat& vertexFormat = part.vertexFormat;
 
 			assert(vertexFormat.attributes != nullptr && vertexFormat.attributeCount > 0);
 
 			// Create vertex array object
-			renderDevice->CreateVertexArrays(1, &primitive.vertexArrayId);
-			kokko::render::VertexArrayId va = primitive.vertexArrayId;
+			renderDevice->CreateVertexArrays(1, &part.vertexArrayId);
+			kokko::render::VertexArrayId va = part.vertexArrayId;
 
 			if (mesh.indexType != RenderIndexType::None)
 				renderDevice->SetVertexArrayIndexBuffer(va, model.bufferId);

--- a/engine/src/Resources/ModelManager.hpp
+++ b/engine/src/Resources/ModelManager.hpp
@@ -42,18 +42,18 @@ struct ModelNode
 
 struct ModelMesh
 {
-	uint16_t primitiveOffset;
-	uint16_t primitiveCount;
+	uint16_t partOffset;
+	uint16_t partCount;
 
-	RenderIndexType indexType = RenderIndexType::None;
-	RenderPrimitiveMode primitiveMode = RenderPrimitiveMode::Triangles;
+	RenderIndexType indexType;
+	RenderPrimitiveMode primitiveMode;
 
 	const char* name;
 
 	AABB aabb;
 };
 
-struct ModelPrimitive
+struct ModelMeshPart
 {
 	uint32_t uniqueVertexCount;
 	uint32_t indexOffset;
@@ -71,12 +71,12 @@ struct ModelData
 
 	ModelNode* nodes = nullptr;
 	ModelMesh* meshes = nullptr;
-	ModelPrimitive* primitives = nullptr;
+	ModelMeshPart* meshParts = nullptr;
 	VertexAttribute* attributes = nullptr;
 
 	uint32_t nodeCount = 0;
 	uint32_t meshCount = 0;
-	uint32_t primitiveCount = 0;
+	uint32_t meshPartCount = 0;
 	uint32_t attributeCount = 0;
 
 	render::BufferId bufferId;
@@ -127,7 +127,7 @@ public:
 
 	ArrayView<const ModelNode> GetModelNodes(ModelId id) const;
 	ArrayView<const ModelMesh> GetModelMeshes(ModelId id) const;
-	ArrayView<const ModelPrimitive> GetModelPrimitives(ModelId id) const;
+	ArrayView<const ModelMeshPart> GetModelMeshParts(ModelId id) const;
 
 private:
 	Allocator* allocator;


### PR DESCRIPTION
To reduce confusion between render primitives (such as triangles or points) and glTF primitives (which describe mesh subparts that could be rendered with different materials), refer to the subparts as mesh parts.