### PR TITLE
Optimize terrain quadtree operation

### DIFF
--- a/engine/src/Graphics/TerrainQuadTree.hpp
+++ b/engine/src/Graphics/TerrainQuadTree.hpp
@@ -5,6 +5,8 @@
 
 #include "Core/Array.hpp"
 
+#include "Math/Vec3.hpp"
+
 class Allocator;
 
 struct FrustumPlanes;
@@ -42,7 +44,7 @@ public:
 		const TerrainParameters& params);
 	void DestroyResources(Allocator* allocator, kokko::render::Device* renderDevice);
 
-	void GetTilesToRender(const FrustumPlanes& frustum, const Mat4x4f& viewProj,
+	void GetTilesToRender(const FrustumPlanes& frustum, const Vec3f& cameraPos,
 		const RenderDebugSettings& renderDebug, Array<TerrainTileId>& resultOut);
 
 	int GetLevelCount() const;
@@ -65,12 +67,15 @@ public:
 	static float GetTileScale(int level);
 
 private:
-	void RenderTile(
-		const TerrainTileId& id,
-		const FrustumPlanes& frustum,
-		const Mat4x4f& vp,
-		const RenderDebugSettings& renderDebug,
-		Array<TerrainTileId>& resultOut);
+	struct GetRenderTilesParams
+	{
+		const FrustumPlanes& frustum;
+		const Vec3f& cameraPos;
+		const RenderDebugSettings& renderDebug;
+		Array<TerrainTileId>& resultOut;
+	};
+
+	void RenderTile(const TerrainTileId& id, GetRenderTilesParams& params);
 
 	static void CreateTileTestData(TerrainTile& tile, int tileX, int tileY, float tileScale);
 

--- a/engine/src/Graphics/TerrainSystem.cpp
+++ b/engine/src/Graphics/TerrainSystem.cpp
@@ -380,7 +380,7 @@ void TerrainSystem::Render(const RenderParameters& parameters)
 	// Select tiles to render
 
 	TerrainQuadTree& quadTree = data.quadTree[id.i];
-	quadTree.GetTilesToRender(viewport.frustum, viewport.viewProjection, parameters.renderDebug, tilesToRender);
+	quadTree.GetTilesToRender(viewport.frustum, viewport.position, parameters.renderDebug, tilesToRender);
 
 	// Update uniform buffer
 

--- a/engine/src/Math/Intersect3D.cpp
+++ b/engine/src/Math/Intersect3D.cpp
@@ -12,8 +12,6 @@
 
 bool Intersect::FrustumAabb(const FrustumPlanes& frustum, const kokko::AABB& bounds)
 {
-	KOKKO_PROFILE_FUNCTION();
-
 	// For each plane in view frustum
 	for (unsigned int planeIdx = 0; planeIdx < 6; ++planeIdx)
 	{


### PR DESCRIPTION
From 0,25 ms to about 0,07 ms on Ryzen 7950X. Fixes #76 