### PR TITLE
Load terrain data based on visible tiles

### DIFF
--- a/engine/src/Graphics/TerrainQuadTree.cpp
+++ b/engine/src/Graphics/TerrainQuadTree.cpp
@@ -134,11 +134,8 @@ TerrainQuadTree::~TerrainQuadTree()
 	if (tileData.textureIds != nullptr)
 		renderDevice->DestroyTextures(tileData.count, tileData.textureIds);
 
-	if (tileData.heightData != nullptr)
-		allocator->Deallocate(tileData.heightData);
-
-	if (tileData.heightData != nullptr)
-		allocator->Deallocate(tileData.textureIds);
+	if (tileData.buffer != nullptr)
+		allocator->Deallocate(tileData.buffer);
 }
 
 void TerrainQuadTree::Initialize(uint8_t levels, const TerrainParameters& params)

--- a/engine/src/Graphics/TerrainQuadTree.cpp
+++ b/engine/src/Graphics/TerrainQuadTree.cpp
@@ -509,11 +509,6 @@ void TerrainQuadTree::LoadTiles()
 	}
 }
 
-int TerrainQuadTree::GetLevelCount() const
-{
-	return treeLevels;
-}
-
 render::TextureId TerrainQuadTree::GetTileHeightTexture(const QuadTreeNodeId& id)
 {
 	auto pair = tileIdToIndexMap.Lookup(id);
@@ -536,28 +531,6 @@ TEST_CASE("TerrainQuadTree.GetTilesPerDimension")
 	CHECK(TerrainQuadTree::GetTilesPerDimension(1) == 2);
 	CHECK(TerrainQuadTree::GetTilesPerDimension(2) == 4);
 	CHECK(TerrainQuadTree::GetTilesPerDimension(3) == 8);
-}
-
-int TerrainQuadTree::GetTileCountForLevelCount(uint8_t levelCount)
-{
-	int levelStart = 0;
-	int levelSize = 1;
-
-	for (int i = 0; i < levelCount; ++i)
-	{
-		levelStart += levelSize * levelSize;
-		levelSize *= 2;
-	}
-
-	return levelStart;
-}
-
-TEST_CASE("TerrainQuadTree.GetTileCountForLevelCount")
-{
-	CHECK(TerrainQuadTree::GetTileCountForLevelCount(0) == 0);
-	CHECK(TerrainQuadTree::GetTileCountForLevelCount(1) == 1);
-	CHECK(TerrainQuadTree::GetTileCountForLevelCount(2) == 5);
-	CHECK(TerrainQuadTree::GetTileCountForLevelCount(3) == 21);
 }
 
 float TerrainQuadTree::GetTileScale(uint8_t level)

--- a/engine/src/Graphics/TerrainQuadTree.cpp
+++ b/engine/src/Graphics/TerrainQuadTree.cpp
@@ -164,8 +164,8 @@ void TerrainQuadTree::UpdateTilesToRender(
 	// Calculates optimal set of tiles to render and updates quad tree <nodes>
 	UpdateTilesToRenderParams params{ frustum, cameraPos, renderDebug };
 	int rootNodeIndex = BuildQuadTree(QuadTreeNodeId{}, params);
-
-	size_t oldNodeCount = nodes.GetCount();
+	if (rootNodeIndex == -1)
+		return;
 
 	// Next we need to update the quad tree so that it forms a restricted quad tree
 	RestrictQuadTree();

--- a/engine/src/Graphics/TerrainQuadTree.hpp
+++ b/engine/src/Graphics/TerrainQuadTree.hpp
@@ -106,7 +106,7 @@ public:
 		const RenderDebugSettings& renderDebug);
 	ArrayView<const TerrainTileDrawInfo> GetTilesToRender() const;
 
-	int GetLevelCount() const;
+	int GetLevelCount() const { return treeLevels; }
 
 	float GetSize() const { return terrainWidth; }
 	void SetSize(float size) { terrainWidth = size; }
@@ -120,7 +120,6 @@ public:
 	render::TextureId GetTileHeightTexture(const QuadTreeNodeId& id);
 
 	static uint32_t GetTilesPerDimension(uint8_t level);
-	static int GetTileCountForLevelCount(uint8_t levelCount);
 	static float GetTileScale(uint8_t level);
 
 private:

--- a/engine/src/Graphics/TerrainQuadTree.hpp
+++ b/engine/src/Graphics/TerrainQuadTree.hpp
@@ -117,11 +117,9 @@ public:
 	float GetHeight() const { return terrainHeight; }
 	void SetHeight(float height) { terrainHeight = height; }
 
-	const TerrainTile* GetTile(uint8_t level, int x, int y);
-	render::TextureId GetTileHeightTexture(uint8_t level, int x, int y);
+	render::TextureId GetTileHeightTexture(const QuadTreeNodeId& id);
 
 	static uint32_t GetTilesPerDimension(uint8_t level);
-	static int GetTileIndex(uint8_t level, int x, int y);
 	static int GetTileCountForLevelCount(uint8_t levelCount);
 	static float GetTileScale(uint8_t level);
 
@@ -163,13 +161,16 @@ private:
 	SortedArray<QuadTreeNodeId> parentsToCheck;
 	SortedArray<QuadTreeNodeId> neighborsToCheck;
 	HashMap<QuadTreeNodeId, EdgeTypeDependents> edgeDependencies; // Key = dependee node, Value = dependent nodes
+	HashMap<QuadTreeNodeId, uint32_t> tileIdToIndexMap;
 
 	struct TileData
 	{
 		TerrainTile* heightData;
 		render::TextureId* textureIds;
 
+		void* buffer;
 		uint32_t count;
+		uint32_t textureInitCount;
 		uint32_t allocated;
 	} tileData;
 

--- a/engine/src/Graphics/TerrainSystem.cpp
+++ b/engine/src/Graphics/TerrainSystem.cpp
@@ -69,7 +69,6 @@ TerrainSystem::TerrainSystem(
 	entityMap(allocator),
 	vertexData(VertexData{}),
 	textureSampler(0),
-	tilesToRender(allocator),
 	uniformStagingBuffer(allocator)
 {
 	data = InstanceData{};
@@ -249,7 +248,7 @@ void TerrainSystem::InitializeTerrain(TerrainId id, const TerrainParameters& par
 	kokko::TerrainQuadTree& quadTree = data.quadTree[id.i];
 
 	constexpr int treeLevels = 7;
-	quadTree.CreateResources(treeLevels, params);
+	quadTree.Initialize(treeLevels, params);
 }
 
 void TerrainSystem::DeinitializeTerrain(TerrainId id)
@@ -401,7 +400,7 @@ void TerrainSystem::Render(const RenderParameters& parameters)
 
 			if (heightMap != nullptr)
 			{
-				render::TextureId heightTex = quadTree.GetTileHeightTexture(tile.id.level, tile.id.x, tile.id.y);
+				render::TextureId heightTex = quadTree.GetTileHeightTexture(tile.id);
 
 				encoder->BindTextureToShader(heightMap->uniformLocation, 0, heightTex);
 			}

--- a/engine/src/Graphics/TerrainSystem.hpp
+++ b/engine/src/Graphics/TerrainSystem.hpp
@@ -135,8 +135,6 @@ private:
 	}
 	data;
 
-	Array<TerrainTileDrawInfo> tilesToRender;
-
 	Array<uint8_t> uniformStagingBuffer;
 
 	void InitializeTerrain(TerrainId id, const TerrainParameters& params);

--- a/engine/src/Graphics/TerrainSystem.hpp
+++ b/engine/src/Graphics/TerrainSystem.hpp
@@ -90,7 +90,8 @@ private:
 	ShaderManager* shaderManager;
 	TextureManager* textureManager;
 	
-	unsigned int uniformBlockStride;
+	uint32_t uniformBlockStride;
+	uint32_t uniformBlocksAllocated;
 	render::BufferId uniformBufferId;
 
 	ShaderId terrainShader;


### PR DESCRIPTION
Fixes #79

This PR changes terrain tile data to be loaded when visible tiles are met. Previously we loaded all tiles possible in the quadtree at terrain load time. This would be a problem if there was too many levels in the quadtree.

New implementation takes many shortcuts
- Tiles are never unloaded
- Tiles aren't loaded from disk, they are generated at runtime