### PR TITLE
Add editor support for texture metadata

### DIFF
--- a/editor/src/App/main.cpp
+++ b/editor/src/App/main.cpp
@@ -138,7 +138,7 @@ int main(int argc, char** argv)
 			engine.StartFrame();
 			editor.StartFrame();
 
-			engine.UpdateWorld();
+			engine.Update();
 
 			// Because editor can change the state of the world and systems,
 			// let's run those updates at the same part of the frame as other updates

--- a/editor/src/System/EditorAssetLoader.cpp
+++ b/editor/src/System/EditorAssetLoader.cpp
@@ -62,5 +62,10 @@ Optional<String> EditorAssetLoader::GetAssetVirtualPath(const Uid& uid)
 	return Optional<String>();
 }
 
+bool EditorAssetLoader::GetNextUpdatedAssetUid(AssetType typeFilter, Uid& uid)
+{
+	return assetLibrary->GetNextUpdatedAssetUid(typeFilter, uid);
 }
-}
+
+} // namespace editor
+} // namespace kokko

--- a/editor/src/System/EditorAssetLoader.cpp
+++ b/editor/src/System/EditorAssetLoader.cpp
@@ -16,18 +16,32 @@ EditorAssetLoader::EditorAssetLoader(Allocator* allocator, Filesystem* filesyste
 {
 }
 
-bool EditorAssetLoader::LoadAsset(const Uid& uid, Array<uint8_t>& output)
+AssetLoader::LoadResult EditorAssetLoader::LoadAsset(const Uid& uid, Array<uint8_t>& output)
 {
 	if (auto asset = assetLibrary->FindAssetByUid(uid))
 	{
-		auto pathStr = asset->GetVirtualPath();
+		LoadResult result;
+		result.assetType = asset->GetType();
+		if (result.assetType == AssetType::Texture)
+		{
+			const TextureAssetMetadata* metadata = assetLibrary->GetTextureMetadata(asset);
+			result.metadataSize = static_cast<uint32_t>(sizeof(TextureAssetMetadata));
+			result.assetStart = Math::RoundUpToMultiple(result.metadataSize, 16u);
+
+			output.Resize(result.assetStart);
+			memcpy(output.GetData(), metadata, result.metadataSize);
+		}
+
+		const String& pathStr = asset->GetVirtualPath();
 		if (filesystem->ReadBinary(pathStr.GetCStr(), output))
 		{
-			return true;
+			result.success = true;
+			result.assetSize = output.GetCount() - result.assetStart;
+			return result;
 		}
 	}
 
-	return false;
+	return LoadResult();
 }
 
 Optional<Uid> EditorAssetLoader::GetAssetUidByVirtualPath(const ConstStringView& path)

--- a/editor/src/System/EditorAssetLoader.hpp
+++ b/editor/src/System/EditorAssetLoader.hpp
@@ -24,6 +24,8 @@ public:
 	virtual Optional<Uid> GetAssetUidByVirtualPath(const ConstStringView& path) override;
 	virtual Optional<String> GetAssetVirtualPath(const Uid& uid) override;
 
+	virtual bool GetNextUpdatedAssetUid(AssetType typeFilter, Uid& uid) override;
+
 private:
 	Filesystem* filesystem;
 	AssetLibrary* assetLibrary;

--- a/editor/src/System/EditorAssetLoader.hpp
+++ b/editor/src/System/EditorAssetLoader.hpp
@@ -20,7 +20,7 @@ class EditorAssetLoader : public AssetLoader
 public:
 	EditorAssetLoader(Allocator* allocator, Filesystem* filesystem, AssetLibrary* assetLibrary);
 
-	virtual bool LoadAsset(const Uid& uid, Array<uint8_t>& output) override;
+	virtual LoadResult LoadAsset(const Uid& uid, Array<uint8_t>& output) override;
 	virtual Optional<Uid> GetAssetUidByVirtualPath(const ConstStringView& path) override;
 	virtual Optional<String> GetAssetVirtualPath(const Uid& uid) override;
 

--- a/editor/src/Views/AssetView.cpp
+++ b/editor/src/Views/AssetView.cpp
@@ -407,11 +407,16 @@ void AssetView::DrawTexture(EditorContext& context, const AssetInfo* asset)
 
 	TextureAssetMetadata metadata = *metadataPtr;
 
-	if (ImGui::Checkbox("Generate mipmaps", &metadata.generateMipmaps))
+	bool changed = false;
+
+	changed |= ImGui::Checkbox("Generate mipmaps", &metadata.generateMipmaps);
+	changed |= ImGui::Checkbox("Prefer linear color", &metadata.preferLinear);
+
+	if (changed)
 	{
 		context.assetLibrary->UpdateTextureMetadata(asset->GetUid(), metadata);
 	}
 }
 
-}
-}
+} // namespace editor
+} // namespace kokko

--- a/editor/src/Views/AssetView.cpp
+++ b/editor/src/Views/AssetView.cpp
@@ -400,6 +400,17 @@ void AssetView::DrawTexture(EditorContext& context, const AssetInfo* asset)
 	ImVec2 uv1(1.0f, 0.0f);
 
 	ImGui::Image(texId, size, uv0, uv1);
+
+	const TextureAssetMetadata* metadataPtr = context.assetLibrary->GetTextureMetadata(asset);
+	if (metadataPtr == nullptr)
+		return;
+
+	TextureAssetMetadata metadata = *metadataPtr;
+
+	if (ImGui::Checkbox("Generate mipmaps", &metadata.generateMipmaps))
+	{
+		context.assetLibrary->UpdateTextureMetadata(asset->GetUid(), metadata);
+	}
 }
 
 }

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -268,6 +268,7 @@ set (KOKKO_SOURCES
 	src/Resources/AssetLibrary.cpp
 	src/Resources/AssetLibrary.hpp
 	src/Resources/AssetLoader.hpp
+	src/Resources/AssetType.hpp
 	src/Resources/BitmapFont.cpp
 	src/Resources/BitmapFont.hpp
 	src/Resources/ImageData.cpp

--- a/engine/src/Core/Uid.hpp
+++ b/engine/src/Core/Uid.hpp
@@ -31,6 +31,16 @@ struct Uid
 		return operator==(other) == false;
 	}
 
+	bool operator<(const Uid& other) const
+	{
+		if (raw[0] < other.raw[0])
+			return true;
+		if (raw[0] > other.raw[0])
+			return false;
+
+		return raw[1] < other.raw[1];
+	}
+
 	void WriteTo(ArrayView<char> out) const;
 };
 

--- a/engine/src/Engine/Engine.cpp
+++ b/engine/src/Engine/Engine.cpp
@@ -135,11 +135,13 @@ void Engine::StartFrame()
 		Instrumentation::Get().EndSession();
 }
 
-void Engine::UpdateWorld()
+void Engine::Update()
 {
 	KOKKO_PROFILE_FUNCTION();
 
 	time->Update();
+	textureManager.instance->Update();
+
 	world.instance->Update(windowManager.instance->GetWindow()->GetInputManager());
 }
 

--- a/engine/src/Engine/Engine.hpp
+++ b/engine/src/Engine/Engine.hpp
@@ -71,7 +71,7 @@ public:
 	bool Initialize(const kokko::WindowSettings& windowSettings);
 
 	void StartFrame();
-	void UpdateWorld();
+	void Update();
 	void Render(const Optional<CameraParameters>& editorCamera, const kokko::render::Framebuffer& framebuffer);
 	void EndFrame();
 

--- a/engine/src/Graphics/EnvironmentSystem.cpp
+++ b/engine/src/Graphics/EnvironmentSystem.cpp
@@ -346,9 +346,9 @@ void EnvironmentSystem::Upload(render::CommandEncoder* encoder)
 			float* equirectData;
 
 			{
-				Array<uint8_t> fileBytes(allocator);
-
-				if (assetLoader->LoadAsset(env.sourceTextureUid.GetValue(), fileBytes) == false)
+				Array<uint8_t> buffer(allocator);
+				AssetLoader::LoadResult loadResult = assetLoader->LoadAsset(env.sourceTextureUid.GetValue(), buffer);
+				if (loadResult.success == false)
 				{
 					KK_LOG_ERROR("Couldn't read source texture for environment map");
 					continue;
@@ -357,9 +357,9 @@ void EnvironmentSystem::Upload(render::CommandEncoder* encoder)
 				{
 					KOKKO_PROFILE_SCOPE("stbi_loadf_from_memory()");
 
-					uint8_t* fileBytesPtr = fileBytes.GetData();
-					int length = static_cast<int>(fileBytes.GetCount());
-					equirectData = stbi_loadf_from_memory(fileBytesPtr, length, &equirectWidth, &equirectHeight, &nrComponents, 0);
+					uint8_t* bytesPtr = buffer.GetData() + loadResult.assetStart;
+					int length = static_cast<int>(loadResult.assetSize);
+					equirectData = stbi_loadf_from_memory(bytesPtr, length, &equirectWidth, &equirectHeight, &nrComponents, 0);
 				}
 			}
 

--- a/engine/src/Resources/AssetLibrary.hpp
+++ b/engine/src/Resources/AssetLibrary.hpp
@@ -78,12 +78,13 @@ public:
 	const AssetInfo* FindAssetByUid(const Uid& uid);
 	const AssetInfo* FindAssetByVirtualPath(const String& virtualPath);
 
-	// Creating a new asset invalidates any pointers obtained from FindAssetBy*()
+	// Creating a new asset invalidates any pointers obtained from FindAsset*() or Get*Metadata()
 	Optional<Uid> CreateAsset(AssetType type, ConstStringView pathRelativeToAssets, ArrayView<const uint8_t> content);
 	bool RenameAsset(const Uid& uid, ConstStringView newFilename);
 	bool UpdateAssetContent(const Uid& uid, ArrayView<const uint8_t> content);
 
 	const TextureAssetMetadata* GetTextureMetadata(const AssetInfo* asset) const;
+	bool UpdateTextureMetadata(const Uid& uid, const TextureAssetMetadata& metadata);
 
 	void SetAppScopeConfig(const AssetScopeConfiguration& config);
 	void SetProjectScopeConfig(const AssetScopeConfiguration& config);

--- a/engine/src/Resources/AssetLibrary.hpp
+++ b/engine/src/Resources/AssetLibrary.hpp
@@ -6,6 +6,7 @@
 #include "Core/Array.hpp"
 #include "Core/HashMap.hpp"
 #include "Core/Optional.hpp"
+#include "Core/SortedArray.hpp"
 #include "Core/String.hpp"
 #include "Core/StringView.hpp"
 #include "Core/Uid.hpp"
@@ -79,6 +80,8 @@ public:
 
 	bool ScanAssets(bool scanEngine, bool scanApp, bool scanProject);
 
+	bool GetNextUpdatedAssetUid(AssetType typeFilter, Uid& uid);
+
 private:
 	uint64_t CalculateHash(AssetType type, ArrayView<const uint8_t> content);
 
@@ -91,6 +94,7 @@ private:
 
 	Array<AssetInfo> assets;
 	Array<TextureAssetMetadata> textureMetadata;
+	SortedArray<Uid> updatedAssets;
 	AssetScopeConfiguration applicationConfig;
 	AssetScopeConfiguration projectConfig;
 };

--- a/engine/src/Resources/AssetLibrary.hpp
+++ b/engine/src/Resources/AssetLibrary.hpp
@@ -10,26 +10,14 @@
 #include "Core/StringView.hpp"
 #include "Core/Uid.hpp"
 
+#include "Resources/AssetType.hpp"
+
 class Allocator;
 
 namespace kokko
 {
 
 class Filesystem;
-
-enum class AssetType : uint8_t
-{
-	Level,
-	Material,
-	Model,
-	Shader,
-	Texture
-};
-
-struct TextureAssetMetadata
-{
-	bool generateMipmaps = true;
-};
 
 struct AssetScopeConfiguration
 {

--- a/engine/src/Resources/AssetLibrary.hpp
+++ b/engine/src/Resources/AssetLibrary.hpp
@@ -17,13 +17,18 @@ namespace kokko
 
 class Filesystem;
 
-enum class AssetType
+enum class AssetType : uint8_t
 {
 	Level,
 	Material,
 	Model,
 	Shader,
 	Texture
+};
+
+struct TextureAssetMetadata
+{
+	bool generateMipmaps = true;
 };
 
 struct AssetScopeConfiguration
@@ -36,7 +41,7 @@ class AssetInfo
 {
 public:
 	AssetInfo(Allocator* allocator, ConstStringView virtualMount, ConstStringView relativePath,
-		Uid uid, uint64_t contentHash, AssetType type);
+		Uid uid, uint64_t contentHash, int32_t metadataIndex, AssetType type);
 
 	void UpdateFilename(ConstStringView newFilename);
 
@@ -60,6 +65,7 @@ private:
 
 	Uid uid;
 	uint64_t contentHash;
+	int32_t metadataIndex;
 	AssetType type;
 };
 
@@ -72,9 +78,12 @@ public:
 	const AssetInfo* FindAssetByUid(const Uid& uid);
 	const AssetInfo* FindAssetByVirtualPath(const String& virtualPath);
 
+	// Creating a new asset invalidates any pointers obtained from FindAssetBy*()
 	Optional<Uid> CreateAsset(AssetType type, ConstStringView pathRelativeToAssets, ArrayView<const uint8_t> content);
 	bool RenameAsset(const Uid& uid, ConstStringView newFilename);
 	bool UpdateAssetContent(const Uid& uid, ArrayView<const uint8_t> content);
+
+	const TextureAssetMetadata* GetTextureMetadata(const AssetInfo* asset) const;
 
 	void SetAppScopeConfig(const AssetScopeConfiguration& config);
 	void SetProjectScopeConfig(const AssetScopeConfiguration& config);
@@ -92,6 +101,7 @@ private:
 	HashMap<String, uint32_t> pathToIndexMap;
 
 	Array<AssetInfo> assets;
+	Array<TextureAssetMetadata> textureMetadata;
 	AssetScopeConfiguration applicationConfig;
 	AssetScopeConfiguration projectConfig;
 };

--- a/engine/src/Resources/AssetLoader.hpp
+++ b/engine/src/Resources/AssetLoader.hpp
@@ -29,6 +29,8 @@ public:
 	virtual LoadResult LoadAsset(const Uid& uid, Array<uint8_t>& output) = 0;
 	virtual Optional<Uid> GetAssetUidByVirtualPath(const ConstStringView& path) = 0;
 	virtual Optional<String> GetAssetVirtualPath(const Uid& uid) = 0;
+
+	virtual bool GetNextUpdatedAssetUid(AssetType typeFilter, Uid& uid) { return false; }
 };
 
 }

--- a/engine/src/Resources/AssetLoader.hpp
+++ b/engine/src/Resources/AssetLoader.hpp
@@ -6,6 +6,8 @@
 #include "Core/Optional.hpp"
 #include "Core/StringView.hpp"
 
+#include "Resources/AssetType.hpp"
+
 namespace kokko
 {
 
@@ -15,7 +17,16 @@ struct Uid;
 class AssetLoader
 {
 public:
-	virtual bool LoadAsset(const Uid& uid, Array<uint8_t>& output) = 0;
+	struct LoadResult
+	{
+		bool success = false;
+		AssetType assetType = AssetType::Unknown;
+		uint32_t metadataSize = 0;
+		uint32_t assetStart = 0;
+		uint32_t assetSize = 0;
+	};
+
+	virtual LoadResult LoadAsset(const Uid& uid, Array<uint8_t>& output) = 0;
 	virtual Optional<Uid> GetAssetUidByVirtualPath(const ConstStringView& path) = 0;
 	virtual Optional<String> GetAssetVirtualPath(const Uid& uid) = 0;
 };

--- a/engine/src/Resources/AssetType.hpp
+++ b/engine/src/Resources/AssetType.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <cstdint>
+
+namespace kokko
+{
+
+enum class AssetType : uint8_t
+{
+	Unknown,
+	Level,
+	Material,
+	Model,
+	Shader,
+	Texture
+};
+
+struct TextureAssetMetadata
+{
+	bool generateMipmaps = true;
+};
+
+}

--- a/engine/src/Resources/AssetType.hpp
+++ b/engine/src/Resources/AssetType.hpp
@@ -18,6 +18,7 @@ enum class AssetType : uint8_t
 struct TextureAssetMetadata
 {
 	bool generateMipmaps = true;
+	bool preferLinear = false;
 };
 
 }

--- a/engine/src/Resources/MaterialManager.cpp
+++ b/engine/src/Resources/MaterialManager.cpp
@@ -147,7 +147,8 @@ MaterialId MaterialManager::FindMaterialByUid(const kokko::Uid& uid)
 
 	Array<uint8_t> file(allocator);
 
-	if (assetLoader->LoadAsset(uid, file))
+	AssetLoader::LoadResult loadResult = assetLoader->LoadAsset(uid, file);
+	if (loadResult.success)
 	{
 		MaterialId id = CreateMaterial();
 

--- a/engine/src/Resources/MaterialSerializer.cpp
+++ b/engine/src/Resources/MaterialSerializer.cpp
@@ -133,7 +133,7 @@ bool MaterialSerializer::DeserializeMaterial(MaterialId id, ConstStringView conf
 			auto uidParseResult = Uid::FromString(uidStrView);
 
 			if (uidParseResult.HasValue())
-				textureId = textureManager->FindTextureByUid(uidParseResult.GetValue(), isNormalTexture);
+				textureId = textureManager->FindTextureByUid(uidParseResult.GetValue());
 		}
 
 		if (textureId == TextureId::Null)

--- a/engine/src/Resources/ModelManager.cpp
+++ b/engine/src/Resources/ModelManager.cpp
@@ -40,7 +40,8 @@ ModelId ModelManager::FindModelByUid(const kokko::Uid& uid)
 
 	Array<uint8_t> file(allocator);
 
-	if (assetLoader->LoadAsset(uid, file))
+	AssetLoader::LoadResult loadResult = assetLoader->LoadAsset(uid, file);
+	if (loadResult.success)
 	{
 		uint32_t id = AcquireSlot();
 		ModelData& model = data.model[id];

--- a/engine/src/Resources/ShaderManager.cpp
+++ b/engine/src/Resources/ShaderManager.cpp
@@ -147,8 +147,8 @@ ShaderId ShaderManager::FindShaderByUid(const kokko::Uid& uid)
 		this->Reallocate(data.count + 1);
 
 	Array<uint8_t> file(allocator);
-
-	if (assetLoader->LoadAsset(uid, file))
+	AssetLoader::LoadResult loadResult = assetLoader->LoadAsset(uid, file);
+	if (loadResult.success)
 	{
 		auto virtualPathResult = assetLoader->GetAssetVirtualPath(uid);
 		const kokko::String& virtualPath = virtualPathResult.GetValue();

--- a/engine/src/Resources/TextureManager.hpp
+++ b/engine/src/Resources/TextureManager.hpp
@@ -94,7 +94,7 @@ public:
 		RenderTextureTarget target, RenderTextureSizedFormat format, int levels, Vec2i size);
 
 private:
-	bool LoadWithStbImage(TextureId id, ArrayView<const uint8_t> bytes, bool preferLinear);
+	bool LoadWithStbImage(TextureId id, ArrayView<const uint8_t> bytes, bool genMipmaps, bool preferLinear);
 };
 
 } // namespace kokko

--- a/engine/src/Resources/TextureManager.hpp
+++ b/engine/src/Resources/TextureManager.hpp
@@ -38,8 +38,8 @@ class TextureManager
 {
 private:
 	Allocator* allocator;
-	kokko::AssetLoader* assetLoader;
-	kokko::render::Device* renderDevice;
+	AssetLoader* assetLoader;
+	render::Device* renderDevice;
 
 	struct InstanceData
 	{
@@ -53,7 +53,7 @@ private:
 	data;
 
 	unsigned int freeListFirst;
-	HashMap<kokko::Uid, TextureId> uidMap;
+	HashMap<Uid, TextureId> uidMap;
 
 	enum ConstantTextures
 	{
@@ -69,7 +69,7 @@ private:
 	void Reallocate(unsigned int required);
 
 public:
-	TextureManager(Allocator* allocator, kokko::AssetLoader* assetLoader, kokko::render::Device* renderDevice);
+	TextureManager(Allocator* allocator, AssetLoader* assetLoader, render::Device* renderDevice);
 	~TextureManager();
 
 	void Initialize();
@@ -77,9 +77,8 @@ public:
 	TextureId CreateTexture();
 	void RemoveTexture(TextureId id);
 
-	// TODO: Create a way for asset loader or some other mechanism to provide the metadata
-	TextureId FindTextureByUid(const kokko::Uid& uid, bool preferLinear = false);
-	TextureId FindTextureByPath(kokko::ConstStringView path, bool preferLinear = false);
+	TextureId FindTextureByUid(const Uid& uid, bool preferLinear = false);
+	TextureId FindTextureByPath(ConstStringView path, bool preferLinear = false);
 
 	TextureId GetId_White2D() const { return constantTextures[ConstTex_White2D]; }
 	TextureId GetId_Black2D() const { return constantTextures[ConstTex_Black2D]; }
@@ -92,6 +91,8 @@ public:
 
 	void AllocateTextureStorage(TextureId id,
 		RenderTextureTarget target, RenderTextureSizedFormat format, int levels, Vec2i size);
+
+	void Update();
 
 private:
 	bool LoadWithStbImage(TextureId id, ArrayView<const uint8_t> bytes, bool genMipmaps, bool preferLinear);

--- a/engine/src/Resources/TextureManager.hpp
+++ b/engine/src/Resources/TextureManager.hpp
@@ -20,6 +20,7 @@ struct ImageData;
 namespace kokko
 {
 class AssetLoader;
+struct TextureAssetMetadata;
 
 namespace render
 {
@@ -77,8 +78,8 @@ public:
 	TextureId CreateTexture();
 	void RemoveTexture(TextureId id);
 
-	TextureId FindTextureByUid(const Uid& uid, bool preferLinear = false);
-	TextureId FindTextureByPath(ConstStringView path, bool preferLinear = false);
+	TextureId FindTextureByUid(const Uid& uid);
+	TextureId FindTextureByPath(ConstStringView path);
 
 	TextureId GetId_White2D() const { return constantTextures[ConstTex_White2D]; }
 	TextureId GetId_Black2D() const { return constantTextures[ConstTex_Black2D]; }
@@ -95,7 +96,7 @@ public:
 	void Update();
 
 private:
-	bool LoadWithStbImage(TextureId id, ArrayView<const uint8_t> bytes, bool genMipmaps, bool preferLinear);
+	bool LoadWithStbImage(TextureId id, ArrayView<const uint8_t> bytes, TextureAssetMetadata metadata);
 };
 
 } // namespace kokko

--- a/engine/src/System/Filesystem.cpp
+++ b/engine/src/System/Filesystem.cpp
@@ -92,9 +92,10 @@ bool Filesystem::ReadBinaryInternal(const char* path, Array<uint8_t>& output)
 		std::rewind(fileHandle);
 
 		// Get the file contents
-		output.Resize(fileLength);
-		size_t read = std::fread(output.GetData(), 1, fileLength, fileHandle);
-		output.Resize(read);
+		size_t origOutputLen = output.GetCount();
+		output.Resize(origOutputLen + fileLength);
+		size_t read = std::fread(output.GetData() + origOutputLen, 1, fileLength, fileHandle);
+		output.Resize(origOutputLen + read);
 
 		std::fclose(fileHandle);
 
@@ -118,10 +119,10 @@ bool Filesystem::ReadTextInternal(const char* path, kokko::String& output)
 		std::rewind(fileHandle);
 
 		// Get the file contents
-		output.Resize(fileLength);
-
-		size_t read = std::fread(output.GetData(), 1, fileLength, fileHandle);
-		output.Resize(read);
+		size_t origOutputLen = output.GetLength();
+		output.Resize(origOutputLen + fileLength);
+		size_t read = std::fread(output.GetData() + origOutputLen, 1, fileLength, fileHandle);
+		output.Resize(origOutputLen + read);
 
 		std::fclose(fileHandle);
 

--- a/render-test/src/TestRunnerAssetLoader.hpp
+++ b/render-test/src/TestRunnerAssetLoader.hpp
@@ -17,7 +17,7 @@ class TestRunnerAssetLoader : public AssetLoader
 public:
 	TestRunnerAssetLoader(Allocator* allocator, Filesystem* filesystem, AssetLibrary* assetLibrary);
 
-	virtual bool LoadAsset(const Uid& uid, Array<uint8_t>& output) override;
+	virtual LoadResult LoadAsset(const Uid& uid, Array<uint8_t>& output) override;
 	virtual Optional<Uid> GetAssetUidByVirtualPath(const ConstStringView& path) override;
 	virtual Optional<String> GetAssetVirtualPath(const Uid& uid) override;
 

--- a/render-test/src/main.cpp
+++ b/render-test/src/main.cpp
@@ -183,7 +183,7 @@ int main(int argc, char** argv)
 				KOKKO_PROFILE_SCOPE("Run render test");
 
 				engine.StartFrame();
-				engine.UpdateWorld();
+				engine.Update();
 				engine.Render(Optional<CameraParameters>(), framebuffer);
 				engine.EndFrame();
 			}


### PR DESCRIPTION
Chose not to implement compression from original ticket because of lot of infrastructure work would have been needed. Now we can edit "generate mipmaps" and "prefer linear color" properties for textures in the editor.

Closes #81 