### PR TITLE
Fix job system synchronization issues

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,8 +19,11 @@ jobs:
               name: "Windows MSVC",
               os: windows-latest,
               generator: "",
+              cmake_defines: "",
               build_type: Release,
               cc: "cl", cxx: "cl",
+              compile_flags: "",
+              link_flags: "",
               dependencies: "",
               build_product: "kokko-editor.exe"
             }
@@ -28,6 +31,27 @@ jobs:
               name: "Linux GCC",
               os: ubuntu-latest,
               generator: "",
+              cmake_defines: "",
+              build_type: Release,
+              cc: "gcc", cxx: "g++",
+              dependencies: "sudo apt-get update && sudo apt-get install xorg-dev",
+              build_product: "kokko-editor"
+            }
+          - {
+              name: "Linux GCC TSan",
+              os: ubuntu-latest,
+              generator: "",
+              cmake_defines: "-DKOKKO_USE_SANITIZER=thread",
+              build_type: Release,
+              cc: "gcc", cxx: "g++",
+              dependencies: "sudo apt-get update && sudo apt-get install xorg-dev",
+              build_product: "kokko-editor"
+            }
+          - {
+              name: "Linux GCC UBSan",
+              os: ubuntu-latest,
+              generator: "",
+              cmake_defines: "-DKOKKO_USE_SANITIZER=undefined",
               build_type: Release,
               cc: "gcc", cxx: "g++",
               dependencies: "sudo apt-get update && sudo apt-get install xorg-dev",
@@ -37,6 +61,7 @@ jobs:
               name: "MacOS Clang",
               os: macos-latest,
               generator: "-G Xcode",
+              cmake_defines: "",
               build_type: Release,
               cc: "clang", cxx: "clang",
               dependencies: "",
@@ -57,11 +82,10 @@ jobs:
         CXX: ${{matrix.config.cxx}}
       run: |
         mkdir build
-        cmake -B build ${{matrix.config.generator}} -DWEBP_BUILD_ANIM_UTILS=OFF -DWEBP_BUILD_CWEBP=OFF -DWEBP_BUILD_DWEBP=OFF -DWEBP_BUILD_LIBWEBPMUX=OFF -DCMAKE_BUILD_TYPE=${{matrix.config.build_type}}
+        cmake -B build ${{matrix.config.generator}} ${{matrix.config.cmake_defines}} -DWEBP_BUILD_ANIM_UTILS=OFF -DWEBP_BUILD_CWEBP=OFF -DWEBP_BUILD_DWEBP=OFF -DWEBP_BUILD_LIBWEBPMUX=OFF -DCMAKE_BUILD_TYPE=${{matrix.config.build_type}}
 
     - name: Build
-      # GitHub runners have 2 vCPU, run 3 parallel build jobs
-      run: cmake --build ${{github.workspace}}/build --config ${{matrix.config.build_type}} --parallel 3
+      run: cmake --build ${{github.workspace}}/build --config ${{matrix.config.build_type}} --parallel
 
     - name: Run tests
       run: |

--- a/editor/CMakeLists.txt
+++ b/editor/CMakeLists.txt
@@ -110,4 +110,9 @@ target_compile_definitions(${EXECUTABLE_NAME} PRIVATE
 	IMGUI_IMPL_OPENGL_LOADER_GLAD
 )
 
+if(KOKKO_USE_SANITIZER)
+target_compile_options(${EXECUTABLE_NAME} INTERFACE -fsanitize=${KOKKO_USE_SANITIZER})
+target_link_options(${EXECUTABLE_NAME} INTERFACE -fsanitize=${KOKKO_USE_SANITIZER})
+endif()
+
 target_link_libraries(${EXECUTABLE_NAME} ${KOKKO_LIB})

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -417,3 +417,8 @@ find_package(OpenGL REQUIRED)
 target_link_libraries(${KOKKO_LIB} PUBLIC OpenGL::GL)
 target_compile_definitions(${KOKKO_LIB} PUBLIC KOKKO_USE_OPENGL)
 endif()
+
+if(KOKKO_USE_SANITIZER)
+target_compile_options(${KOKKO_LIB} INTERFACE -fsanitize=${KOKKO_USE_SANITIZER})
+target_link_options(${KOKKO_LIB} INTERFACE -fsanitize=${KOKKO_USE_SANITIZER})
+endif()

--- a/engine/src/Engine/JobSystem.cpp
+++ b/engine/src/Engine/JobSystem.cpp
@@ -86,11 +86,11 @@ void JobSystem::Deinitialize()
 		for (int i = 0; i < workerCount; ++i)
 			workers[i].RequestExit();
 
-		// Lock must be acquired before notifying the condition
-		std::unique_lock<std::mutex> lock(conditionMutex);
-		lock.unlock();
-
-		jobAddedCondition.notify_all();
+		{
+			// Lock must be acquired before notifying the condition 
+			std::lock_guard<std::mutex> lock(conditionMutex);
+			jobAddedCondition.notify_all();
+		}
 
 		for (int i = 0; i < workerCount; ++i)
 			workers[i].WaitToExit();


### PR DESCRIPTION
Fix specific problems:
- At deinit, a mutex was not properly locked when signaling the condition variable
- When calling Pop on a job queue
  - The CAS operation used relaxed memory ordering, while it should have been acquire-release
  - The CAS API also differed from reference implementation, which caused local variable to be incorrectly modified

The system is much more stable now, but sometimes it is still possible to create a deadlock while waiting for the threads to exit.